### PR TITLE
fix(PPDSC-2105): remove unnecessarily disabled a11y rules in cmp tests

### DIFF
--- a/src/banner/__tests__/banner.stories.tsx
+++ b/src/banner/__tests__/banner.stories.tsx
@@ -200,7 +200,7 @@ const bannerLink = (
 export default {
   title: 'NewsKit Light/banner',
   component: () => 'None',
-  disabledRules: ['color-contrast'],
+  disabledRules: [],
 };
 
 export const StoryBannerDefault = () => (

--- a/src/drawer/__tests__/drawer-layouts.stories.tsx
+++ b/src/drawer/__tests__/drawer-layouts.stories.tsx
@@ -70,7 +70,7 @@ const CategoryRow = ({children}: {children: string}) => (
 export default {
   title: 'NewsKit Light/drawer-layouts-only',
   component: () => 'None',
-  disabledRules: ['tabindex', 'heading-order'],
+  disabledRules: ['tabindex'],
 };
 
 export const StoryRightPlacement = () =>

--- a/src/form/__tests__/form-input.stories.tsx
+++ b/src/form/__tests__/form-input.stories.tsx
@@ -49,7 +49,7 @@ const validateUserName = async (value: string) => {
 export default {
   title: 'NewsKit Light/form-input',
   component: () => 'None',
-  disabledRules: ['color-contrast'],
+  disabledRules: [],
 };
 
 export const StoryFormField = () => (

--- a/src/menu/__tests__/menu.stories.tsx
+++ b/src/menu/__tests__/menu.stories.tsx
@@ -55,7 +55,7 @@ const MenuGroupTitle = () => (
 export default {
   title: 'NewsKit Light/menu',
   component: () => 'None',
-  disabledRules: ['color-contrast'],
+  disabledRules: [],
 };
 
 export const StoryMenuItemsHorizontal = () => (

--- a/src/modal/__tests__/modal-layouts.stories.tsx
+++ b/src/modal/__tests__/modal-layouts.stories.tsx
@@ -67,7 +67,7 @@ const myCustomTheme = createTheme({
 export default {
   title: 'NewsKit Light/modal-layouts-only',
   component: () => 'None',
-  disabledRules: ['tabindex', 'heading-order', 'color-contrast'],
+  disabledRules: ['tabindex'],
 };
 
 export const StoryDefault = () =>

--- a/src/modal/__tests__/modal.stories.tsx
+++ b/src/modal/__tests__/modal.stories.tsx
@@ -45,7 +45,7 @@ const useActiveState = (initial = false): [boolean, () => void, () => void] => {
 export default {
   title: 'NewsKit Light/modal',
   component: () => 'None',
-  disabledRules: ['tabindex', 'color-contrast'], // Because of scenario 'open on page load'
+  disabledRules: ['tabindex'], // Because of scenario 'open on page load'
 };
 
 export const StoryDefault = () =>

--- a/src/structured-list/__tests__/structured-list.stories.tsx
+++ b/src/structured-list/__tests__/structured-list.stories.tsx
@@ -110,7 +110,7 @@ const listItemWithOneCell = (
 export default {
   title: 'NewsKit Light/structured-list',
   component: () => 'None',
-  disabledRules: ['listitem'],
+  disabledRules: [],
 };
 
 export const StoryStructuredListDefault = () => (

--- a/src/toast/__tests__/toast.stories.tsx
+++ b/src/toast/__tests__/toast.stories.tsx
@@ -101,7 +101,7 @@ const toastLink = (
 export default {
   title: 'NewsKit Light/toast',
   component: () => 'None',
-  disabledRules: ['color-contrast'],
+  disabledRules: [],
 };
 
 export const StoryToastDefault = () => (


### PR DESCRIPTION
[PPDSC-2105](https://nidigitalsolutions.jira.com/browse/PPDSC-2105)

**What**

1. Background: Some component stories specify a11y rules to be disabled when running cypress-axe tests. Some of these components are now compliant and the disabled rules can be re-enabled.  
2. Re-enabled any unnecessarily disabled rules in the tests.

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected

**How to test:**
* Run `accessibilty.spec.ts` and all tests should still pass despite fewer disabled rules. 
