### PR TITLE
fix(PPDSC-2134): make BaseSwitch data-testid overridable

### DIFF
--- a/src/base-switch/base-switch.tsx
+++ b/src/base-switch/base-switch.tsx
@@ -172,6 +172,7 @@ export const BaseSwitch = React.forwardRef<HTMLInputElement, BaseSwitchProps>(
               overrides={overrides}
               checked={checked}
               disabled={state === 'disabled'}
+              data-testid={`${type}-input`}
               {...restProps}
               state={state}
               onFocus={composeEventHandlers([onInputFocus, onFocus])}
@@ -179,7 +180,6 @@ export const BaseSwitch = React.forwardRef<HTMLInputElement, BaseSwitchProps>(
               onChange={composeEventHandlers([onInputChange, onChange])}
               path={path}
               type={type}
-              data-testid={`${type}-input`}
             />
           </StyledSwitch>
         </StyledSwitchContainer>

--- a/src/checkbox/__tests__/checkbox.test.tsx
+++ b/src/checkbox/__tests__/checkbox.test.tsx
@@ -168,4 +168,15 @@ describe('Checkbox', () => {
     fireEvent.mouseLeave(feedback);
     expect(asFragment()).toMatchSnapshot('without hover');
   });
+
+  test('override data-testid', () => {
+    const dataTestId = 'override-testid';
+
+    const {getByTestId} = renderWithTheme(() => (
+      <Checkbox data-testid={dataTestId} />
+    ));
+    const checkbox = getByTestId(dataTestId);
+
+    expect(checkbox).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
PPDSC-2134

**What**

The consumers couldn't override the `data-testid` prop so we moved the default one above the `{...restProps}`. This way it can be overridden if necessary. 

**I have done:**
- [x] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected

