### PR TITLE
fix(PPDSC-2047): Resolve gaps in buffering seekbar by refactoring formatTrackData

### DIFF
--- a/src/audio-player-composable/__tests__/audio-player-composable.test.tsx
+++ b/src/audio-player-composable/__tests__/audio-player-composable.test.tsx
@@ -593,14 +593,12 @@ describe('Audio Player Composable', () => {
       expect(mockGetTrackBackground).toHaveBeenCalledWith({
         colors: [
           `${seekBarIndicator.base!.backgroundColor}`, // indicator
-          `${seekBarBuffering.base!.backgroundColor}`, // buffered
-          `${seekBarTrack.base!.backgroundColor}`, // track background
-          `${seekBarTrack.base!.backgroundColor}`, // track background
+          `${seekBarBuffering.base!.backgroundColor}`, // buffered// track background
           `${seekBarTrack.base!.backgroundColor}`, // track background
         ],
         max: 6610,
         min: 0,
-        values: [10, 14, 20, 20],
+        values: [10, 14],
       });
 
       // Audio player snapshot last (so that buffering is included)

--- a/src/audio-player-composable/__tests__/audio-player-composable.test.tsx
+++ b/src/audio-player-composable/__tests__/audio-player-composable.test.tsx
@@ -595,7 +595,7 @@ describe('Audio Player Composable', () => {
           `${seekBarIndicator.base!.backgroundColor}`, // indicator
           `${seekBarBuffering.base!.backgroundColor}`, // buffered
           `${seekBarTrack.base!.backgroundColor}`, // track background
-          `${seekBarBuffering.base!.backgroundColor}`, // buffered
+          `${seekBarTrack.base!.backgroundColor}`, // track background
           `${seekBarTrack.base!.backgroundColor}`, // track background
         ],
         max: 6610,

--- a/src/audio-player-composable/__tests__/utils.test.tsx
+++ b/src/audio-player-composable/__tests__/utils.test.tsx
@@ -60,6 +60,7 @@ describe('formatTrackData', () => {
   test('when multiple buffered sections exist', () => {
     // This can occur when a user moves ahead then back again, multiple disparate buffered sections can exist.
     // Example here is buffered sections exist between 0-125 and 216-228. The current play position is at 32.
+    // It has been diecided to only show the first buffer section similar to how youtube does it.
     expect(
       formatTrackData('track', 'indicator', 'buffer', [32], {
         length: 2,
@@ -67,8 +68,21 @@ describe('formatTrackData', () => {
         end: (i: number) => [125, 228][i],
       }),
     ).toEqual({
-      colors: ['indicator', 'buffer', 'track', 'buffer', 'track'],
+      colors: ['indicator', 'buffer', 'track', 'track', 'track'],
       values: [32, 125, 216, 228],
+    });
+  });
+
+  test('Ensure start is not first value in buffer array', () => {
+    expect(
+      formatTrackData('track', 'indicator', 'buffer', [50], {
+        length: 3,
+        start: (i: number) => [0, 100, 150][i],
+        end: (i: number) => [49, 149, 199][i],
+      }),
+    ).toEqual({
+      colors: ['indicator', 'buffer', 'track', 'track', 'track'],
+      values: [50, 149, 150, 199],
     });
   });
 

--- a/src/audio-player-composable/__tests__/utils.test.tsx
+++ b/src/audio-player-composable/__tests__/utils.test.tsx
@@ -60,7 +60,7 @@ describe('formatTrackData', () => {
   test('when multiple buffered sections take the nearest to the curser time (start time is closest)', () => {
     // This can occur when a user moves ahead then back again, multiple disparate buffered sections can exist.
     // Example here is buffered sections exist between 0-125 and 216-228. The current play position is at 32.
-    // It has been diecided to only show the first buffer section similar to how youtube does it.
+    // It has been decided to only show the first buffer section similar to how youtube does it.
     expect(
       formatTrackData('track', 'indicator', 'buffer', [32], {
         length: 2,

--- a/src/audio-player-composable/__tests__/utils.test.tsx
+++ b/src/audio-player-composable/__tests__/utils.test.tsx
@@ -57,7 +57,7 @@ describe('formatTrackData', () => {
     });
   });
 
-  test('when multiple buffered sections exist', () => {
+  test('when multiple buffered sections take the nearest to the curser time (start time is closest)', () => {
     // This can occur when a user moves ahead then back again, multiple disparate buffered sections can exist.
     // Example here is buffered sections exist between 0-125 and 216-228. The current play position is at 32.
     // It has been diecided to only show the first buffer section similar to how youtube does it.
@@ -68,21 +68,21 @@ describe('formatTrackData', () => {
         end: (i: number) => [125, 228][i],
       }),
     ).toEqual({
-      colors: ['indicator', 'buffer', 'track', 'track', 'track'],
-      values: [32, 125, 216, 228],
+      colors: ['indicator', 'buffer', 'track'],
+      values: [32, 125],
     });
   });
 
-  test('Ensure start is not first value in buffer array', () => {
+  test('when multiple buffered sections take the nearest to the curser time (end time is closest', () => {
     expect(
-      formatTrackData('track', 'indicator', 'buffer', [50], {
-        length: 3,
-        start: (i: number) => [0, 100, 150][i],
-        end: (i: number) => [49, 149, 199][i],
+      formatTrackData('track', 'indicator', 'buffer', [122], {
+        length: 2,
+        start: (i: number) => [0, 216][i],
+        end: (i: number) => [125, 228][i],
       }),
     ).toEqual({
-      colors: ['indicator', 'buffer', 'track', 'track', 'track'],
-      values: [50, 149, 150, 199],
+      colors: ['indicator', 'buffer', 'track'],
+      values: [122, 125],
     });
   });
 

--- a/src/audio-player-composable/components/seek-bar/utils.ts
+++ b/src/audio-player-composable/components/seek-bar/utils.ts
@@ -10,7 +10,7 @@ export const formatTrackData = (
   }
 
   const time = timeArr[0];
-  const bufferPositions = [];
+  const bufferPositions: {type: 'start' | 'end'; value: number}[] = [];
   const closestBuffer = [];
 
   const {length} = buffered;

--- a/src/audio-player-composable/components/seek-bar/utils.ts
+++ b/src/audio-player-composable/components/seek-bar/utils.ts
@@ -10,24 +10,28 @@ export const formatTrackData = (
   }
 
   const time = timeArr[0];
-  const bufferPositions = [];
+  let bufferPositions = [];
+  let bufferObjectArray = [];
 
   const {length} = buffered;
   for (let i = 0; i < length; i += 1) {
-    const startPosition = buffered.start(i);
-    if (startPosition > time) {
-      bufferPositions.push(startPosition);
-    }
-
-    const endPosition = buffered.end(i);
-    if (endPosition > time) {
-      bufferPositions.push(endPosition);
-    }
+    bufferObjectArray.push({type: 'start', value: buffered.start(i)});
+    bufferObjectArray.push({type: 'end', value: buffered.end(i)});
   }
+
+  bufferObjectArray = bufferObjectArray.filter(val => val.value > time);
+  if (bufferObjectArray[0] && bufferObjectArray[0].type === 'start') {
+    bufferObjectArray.shift();
+  }
+
+  bufferPositions = bufferObjectArray.map(val => val.value);
 
   const colors = [
     indicatorColor,
-    ...bufferPositions.map((x, i) => (i % 2 ? trackColor : bufferColor)),
+    ...bufferPositions.map((x, i) => {
+      if (i === 0) return bufferColor;
+      return trackColor;
+    }),
     trackColor,
   ];
   const values = [time, ...bufferPositions];

--- a/src/audio-player-composable/components/seek-bar/utils.ts
+++ b/src/audio-player-composable/components/seek-bar/utils.ts
@@ -11,7 +11,7 @@ export const formatTrackData = (
 
   const time = timeArr[0];
   const bufferPositions: {type: 'start' | 'end'; value: number}[] = [];
-  const closestBuffer = [];
+  let closestBuffer: number = 0;
 
   const {length} = buffered;
   for (let i = 0; i < length; i += 1) {
@@ -41,17 +41,17 @@ export const formatTrackData = (
 
     if (value) {
       // set value for buffer
-      closestBuffer.push(value);
+      closestBuffer = value;
     }
   }
 
   const colors = [
     indicatorColor,
-    ...closestBuffer.map(() => bufferColor),
+    ...(closestBuffer ? [closestBuffer] : []).map(() => bufferColor),
     trackColor,
   ];
 
-  const values = [time, ...closestBuffer];
+  const values = closestBuffer ? [time, closestBuffer] : [time];
   return {colors, values};
 };
 


### PR DESCRIPTION
PPDSC-2047

**What**

1. When user moves the seekbar curser manually multiple disparate buffered sections can exist. However these seem to switch to the mirror opposite to what there where when you stop moving the curser.
2. It was agreed to make it act more like the buffer on Youtube. You now only see the first buffer closet to the curser.
3. You should not see multiple buffers. Buffer will be by the curser though its size depends on what is returned by the audio elements buffer property (so if can fluctuate in size).

<img width="1069" alt="Screenshot 2022-05-23 at 1 31 33 pm" src="https://user-images.githubusercontent.com/11298045/169819911-a3e67398-d4c9-4f32-8df3-c4c8589856cb.png">


<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [x] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
