### PR TITLE
fix(PPDSC-2203): handling non text children in Paragraph

### DIFF
--- a/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -746,10 +746,10 @@ exports[`Sidebar renders correctly when closed 1`] = `
 .emotion-504 {
   margin: 0;
   color: #2E2E2E;
-  font-family: "Poppins",sans-serif;
+  font-family: "DM Sans",sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
 }
 
@@ -7278,10 +7278,10 @@ exports[`Sidebar renders correctly when open 1`] = `
 .emotion-504 {
   margin: 0;
   color: #2E2E2E;
-  font-family: "Poppins",sans-serif;
+  font-family: "DM Sans",sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
 }
 

--- a/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -746,10 +746,10 @@ exports[`Sidebar renders correctly when closed 1`] = `
 .emotion-504 {
   margin: 0;
   color: #2E2E2E;
-  font-family: "DM Sans",sans-serif;
+  font-family: "Poppins",sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 400;
+  font-weight: 500;
   letter-spacing: 0;
 }
 
@@ -7278,10 +7278,10 @@ exports[`Sidebar renders correctly when open 1`] = `
 .emotion-504 {
   margin: 0;
   color: #2E2E2E;
-  font-family: "DM Sans",sans-serif;
+  font-family: "Poppins",sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 400;
+  font-weight: 500;
   letter-spacing: 0;
 }
 

--- a/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
+++ b/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Paragraph does not render dropCap when first children is not plain text 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  margin: 0;
+  color: #2E2E2E;
+  font-family: "DM Sans",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.emotion-0 svg {
+  fill: #2E2E2E;
+}
+
+<p
+    class="emotion-0"
+  >
+    <b>
+      paragraph
+    </b>
+     component
+  </p>
+</DocumentFragment>
+`;
+
 exports[`Paragraph renders Paragraph 1`] = `
 <DocumentFragment>
   .emotion-0 {
@@ -28,7 +55,7 @@ exports[`Paragraph renders Paragraph with overrides 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin: 0;
-  color: #FFFFFF;
+  color: #2E2E2E;
   font-family: "DM Sans",sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -37,7 +64,7 @@ exports[`Paragraph renders Paragraph with overrides 1`] = `
 }
 
 .emotion-0 svg {
-  fill: #FFFFFF;
+  fill: #2E2E2E;
 }
 
 <p
@@ -73,14 +100,6 @@ exports[`Paragraph renders empty Paragraph with dropCap without crashing  1`] = 
 exports[`Paragraph renders with drop cap 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  max-width: 100%;
-}
-
-.emotion-1 {
   margin: 0;
   color: #2E2E2E;
   font-family: "DM Sans",sans-serif;
@@ -90,44 +109,43 @@ exports[`Paragraph renders with drop cap 1`] = `
   letter-spacing: 0;
 }
 
-.emotion-1 svg {
+.emotion-0 svg {
   fill: #2E2E2E;
 }
 
-.emotion-2 {
-  margin: 0;
+.emotion-1 {
+  margin: 0 0 0 0.15em;
   float: left;
-  margin-right: 0.15em;
   margin-top: 4px;
   color: #0A0A0A;
 }
 
 @media screen and (max-width: 767px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.625em;
     line-height: 0.85;
   }
 }
 
 @media screen and (min-width: 768px) and (max-width: 1023px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 5.875em;
     line-height: 0.85;
   }
 }
 
 @media screen and (min-width: 1024px) {
-  .emotion-2 {
+  .emotion-1 {
     font-size: 6em;
     line-height: 0.85;
   }
 }
 
-.emotion-2 svg {
+.emotion-1 svg {
   fill: #0A0A0A;
 }
 
-.emotion-3 {
+.emotion-2 {
   display: block;
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(100%);
@@ -139,26 +157,117 @@ exports[`Paragraph renders with drop cap 1`] = `
   width: 1px;
 }
 
-<div
+<p
     class="emotion-0"
   >
-    <p
+    <span
       aria-hidden="true"
-      class="emotion-1"
     >
       <span
-        class="emotion-2"
+        class="emotion-1"
       >
         p
       </span>
-      aragraph component
-    </p>
-    <span
-      class="emotion-3"
-    >
-      paragraph component
+      aragraph 
     </span>
-  </div>
+    <span
+      class="emotion-2"
+    >
+      paragraph
+    </span>
+    component
+  </p>
+</DocumentFragment>
+`;
+
+exports[`Paragraph renders with drop cap and complex children 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  margin: 0;
+  color: #2E2E2E;
+  font-family: "DM Sans",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.emotion-0 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-1 {
+  margin: 0 0 0 0.15em;
+  float: left;
+  margin-top: 4px;
+  color: #0A0A0A;
+}
+
+@media screen and (max-width: 767px) {
+  .emotion-1 {
+    font-size: 5.625em;
+    line-height: 0.85;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1023px) {
+  .emotion-1 {
+    font-size: 5.875em;
+    line-height: 0.85;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .emotion-1 {
+    font-size: 6em;
+    line-height: 0.85;
+  }
+}
+
+.emotion-1 svg {
+  fill: #0A0A0A;
+}
+
+.emotion-2 {
+  display: block;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<p
+    class="emotion-0"
+  >
+    <span
+      aria-hidden="true"
+    >
+      <span
+        class="emotion-1"
+      >
+        p
+      </span>
+      aragraph 
+    </span>
+    <span
+      class="emotion-2"
+    >
+      paragraph
+    </span>
+    <b>
+      component
+    </b>
+     with 
+    <a
+      href="/"
+    >
+      link
+    </a>
+  </p>
 </DocumentFragment>
 `;
 

--- a/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
+++ b/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`Paragraph renders with drop cap 1`] = `
 }
 
 .emotion-1 {
-  margin: 0 0 0 0.15em;
+  margin: 0 0.15em 0 0;
   float: left;
   margin-top: 4px;
   color: #0A0A0A;
@@ -197,7 +197,7 @@ exports[`Paragraph renders with drop cap and complex children 1`] = `
 }
 
 .emotion-1 {
-  margin: 0 0 0 0.15em;
+  margin: 0 0.15em 0 0;
   float: left;
   margin-top: 4px;
   color: #0A0A0A;

--- a/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
+++ b/src/typography/__tests__/__snapshots__/paragraph.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Paragraph renders Paragraph with overrides 1`] = `
 <DocumentFragment>
   .emotion-0 {
   margin: 0;
-  color: #2E2E2E;
+  color: #FFFFFF;
   font-family: "DM Sans",sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -64,7 +64,7 @@ exports[`Paragraph renders Paragraph with overrides 1`] = `
 }
 
 .emotion-0 svg {
-  fill: #2E2E2E;
+  fill: #FFFFFF;
 }
 
 <p
@@ -145,7 +145,18 @@ exports[`Paragraph renders with drop cap 1`] = `
   fill: #0A0A0A;
 }
 
-.emotion-2 {
+<p
+    aria-hidden="true"
+    class="emotion-0"
+  >
+    <span
+      class="emotion-1"
+    >
+      p
+    </span>
+    aragraph component
+  </p>
+  .emotion-0 {
   display: block;
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(100%);
@@ -157,26 +168,11 @@ exports[`Paragraph renders with drop cap 1`] = `
   width: 1px;
 }
 
-<p
+<span
     class="emotion-0"
   >
-    <span
-      aria-hidden="true"
-    >
-      <span
-        class="emotion-1"
-      >
-        p
-      </span>
-      aragraph 
-    </span>
-    <span
-      class="emotion-2"
-    >
-      paragraph
-    </span>
-    component
-  </p>
+    paragraph component
+  </span>
 </DocumentFragment>
 `;
 
@@ -228,7 +224,27 @@ exports[`Paragraph renders with drop cap and complex children 1`] = `
   fill: #0A0A0A;
 }
 
-.emotion-2 {
+<p
+    aria-hidden="true"
+    class="emotion-0"
+  >
+    <span
+      class="emotion-1"
+    >
+      p
+    </span>
+    aragraph 
+    <b>
+      component
+    </b>
+     with 
+    <a
+      href="/"
+    >
+      link
+    </a>
+  </p>
+  .emotion-0 {
   display: block;
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(100%);
@@ -240,24 +256,10 @@ exports[`Paragraph renders with drop cap and complex children 1`] = `
   width: 1px;
 }
 
-<p
+<span
     class="emotion-0"
   >
-    <span
-      aria-hidden="true"
-    >
-      <span
-        class="emotion-1"
-      >
-        p
-      </span>
-      aragraph 
-    </span>
-    <span
-      class="emotion-2"
-    >
-      paragraph
-    </span>
+    paragraph 
     <b>
       component
     </b>
@@ -267,7 +269,7 @@ exports[`Paragraph renders with drop cap and complex children 1`] = `
     >
       link
     </a>
-  </p>
+  </span>
 </DocumentFragment>
 `;
 

--- a/src/typography/__tests__/paragraph.stories.tsx
+++ b/src/typography/__tests__/paragraph.stories.tsx
@@ -48,6 +48,18 @@ export const StoryParagraph = () => (
       Week.
     </P>
     <br />
+    <StorybookSubHeading>
+      with drop cap and multiply children
+    </StorybookSubHeading>
+    <P dropCap>
+      This being <strong>Black History Month</strong>, last week was Politicians
+      In Search Of An Eye-Catching Race-Related Policy Week. Both Theresa May
+      and <strong>Jeremy Corbyn</strong> had their own announcement, each
+      seemingly benign and right-on, each actually destructive and wrong-headed.
+      This being Black History Month, last week was
+      <i>Politicians In Search Of An Eye-Catching Race-Related Policy Week</i>.
+    </P>
+    <br />
     <StorybookSubHeading>with Sup and Sub elements</StorybookSubHeading>
     <P>
       Paragraph component containing a <Sub>subscript element</Sub> and a{' '}

--- a/src/typography/__tests__/paragraph.test.tsx
+++ b/src/typography/__tests__/paragraph.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   Paragraph,
   P,
@@ -38,6 +39,30 @@ describe('Paragraph', () => {
   test('renders with drop cap', () => {
     const wrapper = renderToFragmentWithTheme(Paragraph, {
       children: 'paragraph component',
+      dropCap: true,
+    } as ParagraphProps);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('renders with drop cap and complex children', () => {
+    const wrapper = renderToFragmentWithTheme(Paragraph, {
+      children: (
+        <>
+          paragraph <b>component</b> with <a href="/">link</a>
+        </>
+      ),
+      dropCap: true,
+    } as ParagraphProps);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('does not render dropCap when first children is not plain text', () => {
+    const wrapper = renderToFragmentWithTheme(Paragraph, {
+      children: (
+        <>
+          <b>paragraph</b> component
+        </>
+      ),
       dropCap: true,
     } as ParagraphProps);
     expect(wrapper).toMatchSnapshot();

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -54,7 +54,7 @@ const getFirstLetter = (
 ): string => {
   const [firstChild] = children;
   if (typeof firstChild === 'string') {
-    return firstChild.split('')[0];
+    return firstChild.charAt(0);
   }
   if (isFragment(firstChild)) {
     return getFirstLetter(React.Children.toArray(firstChild.props.children));
@@ -67,7 +67,7 @@ const removeFirstLetter = (
 ): (React.ReactChild | React.ReactFragment | React.ReactPortal)[] => {
   const [firstChild, ...rest] = children;
   if (typeof firstChild === 'string') {
-    return [firstChild.split('').slice(1).join(''), ...rest];
+    return [firstChild.substring(1), ...rest];
   }
   if (isFragment(firstChild)) {
     return [

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -76,6 +76,7 @@ const removeFirstLetter = (
     ];
   }
 
+  /* istanbul ignore next */
   return children;
 };
 

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -35,7 +35,7 @@ export const ParagraphText = withOwnTheme(ThemelessParagraphText)({
 });
 
 const ThemelessParagraphDropCap = styled.span<ParagraphProps>`
-  margin: 0 0 0 0.15em;
+  margin: 0 0.15em 0 0;
   float: left;
   ${getResponsiveSpace('marginTop', 'paragraph.dropCap', 'dropCap', 'space')};
   ${getTypographyPreset('paragraph.dropCap', 'dropCap')};

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -52,26 +52,28 @@ export const ParagraphDropCap = withOwnTheme(ThemelessParagraphDropCap)({
 const getFirstWord = (
   children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[],
 ): string => {
-  if (children.length > 0 && typeof children[0] === 'string') {
-    return children[0].split(' ')[0];
+  const [firstChild] = children;
+  if (children.length > 0 && typeof firstChild === 'string') {
+    return firstChild.split(' ')[0];
   }
-  if (children.length && isFragment(children[0])) {
-    return getFirstWord(React.Children.toArray(children[0].props.children));
+  if (children.length && isFragment(firstChild)) {
+    return getFirstWord(React.Children.toArray(firstChild.props.children));
   }
   return '';
 };
 
 const removeFirstWord = (
   children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[],
-) => {
-  if (children.length > 0 && typeof children[0] === 'string') {
-    // eslint-disable-next-line no-param-reassign
-    children[0] = children[0].split(' ').slice(1).join(' ');
-  } else if (children.length && isFragment(children[0])) {
-    // eslint-disable-next-line no-param-reassign
-    children[0] = removeFirstWord(
-      React.Children.toArray(children[0].props.children),
-    );
+): (React.ReactChild | React.ReactFragment | React.ReactPortal)[] => {
+  const [firstChild, ...rest] = children;
+  if (children.length > 0 && typeof firstChild === 'string') {
+    return [firstChild.split(' ').slice(1).join(' '), ...rest];
+  }
+  if (children.length && isFragment(firstChild)) {
+    return [
+      removeFirstWord(React.Children.toArray(firstChild.props.children)),
+      ...rest,
+    ];
   }
 
   return children;
@@ -89,12 +91,12 @@ Creating the fallowing structure:
  */
 
 export const Paragraph: React.FC<ParagraphProps> = ({
-  children: ch,
+  children,
   overrides = {},
   dropCap = false,
 }) => {
-  const children = React.Children.toArray(ch);
-  const firstWord = getFirstWord(children);
+  const childrenAsArray = React.Children.toArray(children);
+  const firstWord = getFirstWord(childrenAsArray);
   const useDropCap = dropCap && firstWord;
 
   return (
@@ -110,7 +112,7 @@ export const Paragraph: React.FC<ParagraphProps> = ({
           <ScreenReaderOnly>{firstWord}</ScreenReaderOnly>
         </>
       )}
-      {useDropCap ? removeFirstWord(children) : children}
+      {useDropCap ? removeFirstWord(childrenAsArray) : childrenAsArray}
     </ParagraphText>
   );
 };

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -49,29 +49,29 @@ export const ParagraphDropCap = withOwnTheme(ThemelessParagraphDropCap)({
   defaults,
 });
 
-const getFirstWord = (
+const getFirstLetter = (
   children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[],
 ): string => {
   const [firstChild] = children;
-  if (children.length > 0 && typeof firstChild === 'string') {
-    return firstChild.split(' ')[0];
+  if (typeof firstChild === 'string') {
+    return firstChild.split('')[0];
   }
-  if (children.length && isFragment(firstChild)) {
-    return getFirstWord(React.Children.toArray(firstChild.props.children));
+  if (isFragment(firstChild)) {
+    return getFirstLetter(React.Children.toArray(firstChild.props.children));
   }
   return '';
 };
 
-const removeFirstWord = (
+const removeFirstLetter = (
   children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[],
 ): (React.ReactChild | React.ReactFragment | React.ReactPortal)[] => {
   const [firstChild, ...rest] = children;
-  if (children.length > 0 && typeof firstChild === 'string') {
-    return [firstChild.split(' ').slice(1).join(' '), ...rest];
+  if (typeof firstChild === 'string') {
+    return [firstChild.split('').slice(1).join(''), ...rest];
   }
-  if (children.length && isFragment(firstChild)) {
+  if (isFragment(firstChild)) {
     return [
-      removeFirstWord(React.Children.toArray(firstChild.props.children)),
+      removeFirstLetter(React.Children.toArray(firstChild.props.children)),
       ...rest,
     ];
   }
@@ -79,41 +79,25 @@ const removeFirstWord = (
   return children;
 };
 
-/**
-
-For a11y reason we need to add aria-hidden to the first word of the paragraph.
-Creating the fallowing structure:
-<p>
-  <span aria-hidden="true"><span class="dropcap">T</span>his</span>
-  <span class="sr-only">This</span> is paragraph text
-</p>          
-
- */
-
 export const Paragraph: React.FC<ParagraphProps> = ({
   children,
   overrides = {},
   dropCap = false,
 }) => {
   const childrenAsArray = React.Children.toArray(children);
-  const firstWord = getFirstWord(childrenAsArray);
-  const useDropCap = dropCap && firstWord;
+  const firstLetter = getFirstLetter(childrenAsArray);
+  const useDropCap = dropCap && firstLetter;
 
-  return (
-    <ParagraphText>
-      {useDropCap && (
-        <>
-          <span aria-hidden="true">
-            <ParagraphDropCap overrides={overrides}>
-              {firstWord[0]}
-            </ParagraphDropCap>
-            {firstWord.slice(1)}{' '}
-          </span>
-          <ScreenReaderOnly>{firstWord}</ScreenReaderOnly>
-        </>
-      )}
-      {useDropCap ? removeFirstWord(childrenAsArray) : childrenAsArray}
-    </ParagraphText>
+  return useDropCap && children ? (
+    <>
+      <ParagraphText aria-hidden="true" overrides={overrides}>
+        <ParagraphDropCap overrides={overrides}>{firstLetter}</ParagraphDropCap>
+        {removeFirstLetter(childrenAsArray)}
+      </ParagraphText>
+      <ScreenReaderOnly>{children}</ScreenReaderOnly>
+    </>
+  ) : (
+    <ParagraphText overrides={overrides}>{children}</ParagraphText>
   );
 };
 

--- a/src/typography/paragraph/paragraph.tsx
+++ b/src/typography/paragraph/paragraph.tsx
@@ -34,6 +34,10 @@ export const ParagraphText = withOwnTheme(ThemelessParagraphText)({
   defaults,
 });
 
+/*
+We use this solution instead of css :first-letter since there is Firefox inconsistences,
+which causes the first letter to has less margin than desired.
+*/
 const ThemelessParagraphDropCap = styled.span<ParagraphProps>`
   margin: 0 0.15em 0 0;
   float: left;


### PR DESCRIPTION
PPDSC-2203

**What**

1. Background - drop-cap on the paragraph component is broken when you use no-text only children like `text <b>other</b>` since for React treads that as multiple children
2. What did you do - 
    2.1. - Updated code so that handles multiple children, and  adjusted the ScreenOnly content, to wrap only first word instead of the whole paragraph text
    2.2. - When the first child is not a text it will not show the drop-cap.
    2.3. - Added support for React.Fragment
4. What does the reviewers should expect

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [x] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
