### PR TITLE
fix(PPDSC-1969): fix CRA errors and warnings

### DIFF
--- a/src/audio-player-composable/audio-functions.ts
+++ b/src/audio-player-composable/audio-functions.ts
@@ -5,7 +5,7 @@ import {AudioEvents, AudioFunctionDependencies} from './types';
 import {formatTrackTime, getMediaSegment} from './utils';
 import calculateStringPercentage from '../utils/calculate-string-percentage';
 import {getValueInRange} from '../utils/value-in-range';
-import {version} from '../version-number.json';
+import versionNumber from '../version-number.json';
 
 export const useAudioFunctions = ({
   autoPlay,
@@ -41,7 +41,7 @@ export const useAudioFunctions = ({
 
   const buildMediaData = useCallback(() => {
     const playerData = {
-      media_player: `newskit-audio-player-${version}`,
+      media_player: `newskit-audio-player-${versionNumber.version}`,
       media_type: 'audio',
     };
     return live

--- a/src/audio-player/audio-functions.ts
+++ b/src/audio-player/audio-functions.ts
@@ -6,7 +6,7 @@ import {formatTrackTime, getMediaSegment} from './utils';
 import calculateStringPercentage from '../utils/calculate-string-percentage';
 import {getValueInRange} from '../utils/value-in-range';
 
-import {version} from '../version-number.json';
+import versionNumber from '../version-number.json';
 
 export interface AudioFunctionDependencies {
   onPreviousTrack: AudioPlayerProps['onPreviousTrack'];
@@ -72,7 +72,7 @@ export const useAudioFunctions = ({
 
   const buildMediaData = useCallback(() => {
     const playerData = {
-      media_player: `newskit-audio-player-${version}`,
+      media_player: `newskit-audio-player-${versionNumber.version}`,
       media_type: 'audio',
     };
     return live

--- a/src/theme/emotion.tsx
+++ b/src/theme/emotion.tsx
@@ -15,6 +15,7 @@ export const useTheme = (_useTheme as unknown) as () => Theme;
 
 export interface ThemeProviderProps {
   theme: UncompiledTheme | Theme | ((outerTheme: Theme) => Theme);
+  children: React.ReactNode;
 }
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   theme,


### PR DESCRIPTION
PPDSC-1969

**What**

Fixed `create-react-app` warnings and errors when using `newskit`.

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [x] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [x] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
