### PR TITLE
feat(PPDSC-2121): popover header close

### DIFF
--- a/src/base-floating-element/base-floating-element.tsx
+++ b/src/base-floating-element/base-floating-element.tsx
@@ -136,19 +136,24 @@ export const BaseFloatingElement: React.FC<BaseFloatingElementProps> = ({
     return children;
   }
 
+  // This object contains the event handlers that should be added to the reference
+  // element (e.g. onClick, etc. if useClick is passed to useInteractions). It is
+  // also passed to the content prop (if this is a function) to allow other elements
+  // to trigger these handlers (e.g. the Popover's close button triggers the onClick
+  // handler).
+  const referenceProps = getReferenceProps();
+
   return (
     <>
-      {React.cloneElement(
-        children,
-        getReferenceProps({
-          ref: composeRefs<Element>(reference, children.ref),
-          ...refElAriaAttributes,
-          id:
-            floatingElAriaAttributes['aria-labelledby'] && !children.props.id
-              ? defaultRefId
-              : undefined,
-        }),
-      )}
+      {React.cloneElement(children, {
+        ref: composeRefs<Element>(reference, children.ref),
+        ...refElAriaAttributes,
+        id:
+          floatingElAriaAttributes['aria-labelledby'] && !children.props.id
+            ? defaultRefId
+            : undefined,
+        ...referenceProps,
+      })}
       {open && (
         <StyledFloatingElement
           {...getFloatingProps({
@@ -174,7 +179,7 @@ export const BaseFloatingElement: React.FC<BaseFloatingElementProps> = ({
             path={path}
             ref={panelRef}
           >
-            {content}
+            {typeof content === 'function' ? content(referenceProps) : content}
           </StyledPanel>
           {!hidePointer && (
             <StyledPointer

--- a/src/base-floating-element/base-floating-element.tsx
+++ b/src/base-floating-element/base-floating-element.tsx
@@ -90,8 +90,8 @@ export const BaseFloatingElement: React.FC<BaseFloatingElementProps> = ({
     ],
   });
 
-  const defaultRefId = useId();
-  const floatingId = useId();
+  const defaultRefId = `ref-${useId()}`;
+  const floatingId = `floating-${useId()}`;
   const ariaArgs = {
     floating: {id: floatingId, open},
     ref: {id: children.props.id || defaultRefId},

--- a/src/base-floating-element/styled.tsx
+++ b/src/base-floating-element/styled.tsx
@@ -45,6 +45,7 @@ export const StyledPointer = styled.div<
     $y?: number;
   } & Pick<BaseFloatingElementProps, 'overrides' | 'path'>
 >`
+  z-index: -1; // This makes sure that the pointer doesn't sit over panel contents.
   position: absolute;
   transform: rotate(45deg);
   box-sizing: border-box;

--- a/src/base-floating-element/types.ts
+++ b/src/base-floating-element/types.ts
@@ -21,13 +21,19 @@ export type BuildAriaAttributesFn = (args: {
   };
 }) => AriaAttributes;
 
+type ReferenceProps = ReturnType<
+  ReturnType<typeof useInteractions>['getReferenceProps']
+>;
+
 export interface FloatingElementProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | 'defaultValue'> {
   children: React.ReactElement & {
     ref?: React.Ref<HTMLElement>;
   };
   trigger?: TriggerType | TriggerType[];
-  content: React.ReactNode;
+  content:
+    | React.ReactNode
+    | ((referenceProps: ReferenceProps) => React.ReactNode);
   open?: boolean;
   placement?: Placement;
   overrides?: {

--- a/src/dialog/styled.tsx
+++ b/src/dialog/styled.tsx
@@ -13,9 +13,9 @@ type BaseDialogViewOverridesAndPathProps = Pick<
   'path' | 'overrides' | 'inline' | 'closePosition'
 > & {$open?: boolean};
 
-const createCssGrid = ({
-  closePosition,
-}: Pick<BaseDialogViewProps, 'closePosition'>) =>
+export const createCssGrid: (
+  props: Pick<BaseDialogViewProps, 'closePosition'>,
+) => ReturnType<typeof css> = ({closePosition}) =>
   closePosition === 'left'
     ? css`
         display: grid;

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -1582,7 +1582,7 @@ exports[`Popover content applies stylePreset overrides 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Popover header applies logical prop overrides 1`] = `
+exports[`Popover content applies typography preset overrides 1`] = `
 <DocumentFragment>
   <button
     aria-controls="MOCK-ID"
@@ -1618,7 +1618,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
 .emotion-3 {
   grid-area: content;
   font-family: "DM Sans",sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   letter-spacing: 0;
@@ -1846,6 +1846,305 @@ exports[`Popover header applies logical prop overrides 1`] = `
     </div>
     <div
       class="emotion-10"
+      id="MOCK-ID-pointer"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover header applies logical prop overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: -24px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: header;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  font-family: "Poppins",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding-inline: 20px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-5 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-6 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-6 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-6:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-6:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-6:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-6:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-9 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-11 {
+  z-index: -1;
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  left: 12px;
+  bottom: calc(-16px / 2);
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="header-text"
+        >
+          header value
+        </div>
+        <div
+          class="emotion-4"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-5"
+        >
+          <button
+            aria-label="close"
+            class="emotion-6"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-7"
+            >
+              <div
+                class="emotion-8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-9 emotion-10"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-11"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -2128,6 +2427,305 @@ exports[`Popover header applies stylePreset overrides 1`] = `
         </div>
       </div>
     </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover header applies typography preset overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: -24px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: header;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding-inline: 24px;
+  padding-block: 16px;
+}
+
+.emotion-4 {
+  grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-5 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-6 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-6 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-6:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-6:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-6:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-6:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-9 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-11 {
+  z-index: -1;
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  left: 12px;
+  bottom: calc(-16px / 2);
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="header-text"
+        >
+          header value
+        </div>
+        <div
+          class="emotion-4"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-5"
+        >
+          <button
+            aria-label="close"
+            class="emotion-6"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-7"
+            >
+              <div
+                class="emotion-8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-9 emotion-10"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-11"
+      id="MOCK-ID-pointer"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -190,6 +190,7 @@ exports[`Popover close button applies logical prop overrides 1`] = `
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -1220,6 +1221,7 @@ exports[`Popover content applies logical prop overrides 1`] = `
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -1770,6 +1772,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -2319,6 +2322,7 @@ exports[`Popover offset should be applied with pointer and px distance override 
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -2588,6 +2592,7 @@ exports[`Popover offset should be applied with pointer and token distance overri
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -2857,6 +2862,7 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -3126,6 +3132,7 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -3646,6 +3653,7 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -3915,6 +3923,7 @@ exports[`Popover pointer padding should be applied with token distance override 
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -4184,6 +4193,7 @@ exports[`Popover pointer padding should not be applied with invalid token distan
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -4453,6 +4463,7 @@ exports[`Popover pointer padding should not be applied with non-px distance over
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -5233,6 +5244,7 @@ exports[`Popover should render correct styles: with pointer 1`] = `
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -5502,6 +5514,7 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -5771,6 +5784,7 @@ exports[`Popover should render correct styles: with pointer stylePreset override
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -6040,6 +6054,7 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
 }
 
 .emotion-10 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -3,9 +3,9 @@
 exports[`Popover close button applies logical prop overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -206,9 +206,9 @@ exports[`Popover close button applies logical prop overrides 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -264,7 +264,7 @@ exports[`Popover close button applies logical prop overrides 1`] = `
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -273,7 +273,7 @@ exports[`Popover close button applies logical prop overrides 1`] = `
 exports[`Popover close button applies stylePreset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
     type="submit"
   >
@@ -465,10 +465,10 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
 }
 
 <div
-    aria-describedby="MOCK-ID"
+    aria-describedby="header-MOCK-ID"
     aria-expanded="true"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -483,7 +483,7 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
-          id="MOCK-ID"
+          id="header-MOCK-ID"
         >
           header value
         </div>
@@ -536,9 +536,9 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
 exports[`Popover close button should show left-aligned 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -722,9 +722,9 @@ exports[`Popover close button should show left-aligned 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -785,9 +785,9 @@ exports[`Popover close button should show left-aligned 1`] = `
 exports[`Popover close button should show right-aligned 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -971,9 +971,9 @@ exports[`Popover close button should show right-aligned 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -1034,9 +1034,9 @@ exports[`Popover close button should show right-aligned 1`] = `
 exports[`Popover content applies logical prop overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -1237,9 +1237,9 @@ exports[`Popover content applies logical prop overrides 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -1295,7 +1295,7 @@ exports[`Popover content applies logical prop overrides 1`] = `
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1304,7 +1304,7 @@ exports[`Popover content applies logical prop overrides 1`] = `
 exports[`Popover content applies stylePreset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
     type="submit"
   >
@@ -1514,10 +1514,10 @@ exports[`Popover content applies stylePreset overrides 1`] = `
 }
 
 <div
-    aria-describedby="MOCK-ID"
+    aria-describedby="header-MOCK-ID"
     aria-expanded="true"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -1532,7 +1532,7 @@ exports[`Popover content applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
-          id="MOCK-ID"
+          id="header-MOCK-ID"
         >
           header value
         </div>
@@ -1585,9 +1585,9 @@ exports[`Popover content applies stylePreset overrides 1`] = `
 exports[`Popover content applies typography preset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -1788,9 +1788,9 @@ exports[`Popover content applies typography preset overrides 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -1846,7 +1846,7 @@ exports[`Popover content applies typography preset overrides 1`] = `
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1855,7 +1855,7 @@ exports[`Popover content applies typography preset overrides 1`] = `
 exports[`Popover header applies logical prop overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
     type="submit"
   >
@@ -2079,10 +2079,10 @@ exports[`Popover header applies logical prop overrides 1`] = `
 }
 
 <div
-    aria-describedby="MOCK-ID"
+    aria-describedby="header-MOCK-ID"
     aria-expanded="true"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -2097,7 +2097,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
-          id="MOCK-ID"
+          id="header-MOCK-ID"
         >
           header value
         </div>
@@ -2145,7 +2145,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
     </div>
     <div
       class="emotion-11"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -2154,7 +2154,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
 exports[`Popover header applies stylePreset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
     type="submit"
   >
@@ -2363,10 +2363,10 @@ exports[`Popover header applies stylePreset overrides 1`] = `
 }
 
 <div
-    aria-describedby="MOCK-ID"
+    aria-describedby="header-MOCK-ID"
     aria-expanded="true"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -2381,7 +2381,7 @@ exports[`Popover header applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
-          id="MOCK-ID"
+          id="header-MOCK-ID"
         >
           header value
         </div>
@@ -2434,7 +2434,7 @@ exports[`Popover header applies stylePreset overrides 1`] = `
 exports[`Popover header applies typography preset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
     type="submit"
   >
@@ -2658,10 +2658,10 @@ exports[`Popover header applies typography preset overrides 1`] = `
 }
 
 <div
-    aria-describedby="MOCK-ID"
+    aria-describedby="header-MOCK-ID"
     aria-expanded="true"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -2676,7 +2676,7 @@ exports[`Popover header applies typography preset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
-          id="MOCK-ID"
+          id="header-MOCK-ID"
         >
           header value
         </div>
@@ -2724,7 +2724,7 @@ exports[`Popover header applies typography preset overrides 1`] = `
     </div>
     <div
       class="emotion-11"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -2733,9 +2733,9 @@ exports[`Popover header applies typography preset overrides 1`] = `
 exports[`Popover offset should be applied with pointer and px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -2936,9 +2936,9 @@ exports[`Popover offset should be applied with pointer and px distance override 
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -2994,7 +2994,7 @@ exports[`Popover offset should be applied with pointer and px distance override 
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -3003,9 +3003,9 @@ exports[`Popover offset should be applied with pointer and px distance override 
 exports[`Popover offset should be applied with pointer and token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -3206,9 +3206,9 @@ exports[`Popover offset should be applied with pointer and token distance overri
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -3264,7 +3264,7 @@ exports[`Popover offset should be applied with pointer and token distance overri
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -3273,9 +3273,9 @@ exports[`Popover offset should be applied with pointer and token distance overri
 exports[`Popover offset should not be applied with pointer and invalid token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -3476,9 +3476,9 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -3534,7 +3534,7 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -3543,9 +3543,9 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
 exports[`Popover offset should not be applied with pointer and non-px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -3746,9 +3746,9 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -3804,7 +3804,7 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -3813,9 +3813,9 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
 exports[`Popover offset should not be applied with with no pointer 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -4001,9 +4001,9 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -4064,9 +4064,9 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
 exports[`Popover pointer padding should be applied with px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -4267,9 +4267,9 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -4325,7 +4325,7 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -4334,9 +4334,9 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
 exports[`Popover pointer padding should be applied with token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -4537,9 +4537,9 @@ exports[`Popover pointer padding should be applied with token distance override 
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -4595,7 +4595,7 @@ exports[`Popover pointer padding should be applied with token distance override 
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -4604,9 +4604,9 @@ exports[`Popover pointer padding should be applied with token distance override 
 exports[`Popover pointer padding should not be applied with invalid token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -4807,9 +4807,9 @@ exports[`Popover pointer padding should not be applied with invalid token distan
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -4865,7 +4865,7 @@ exports[`Popover pointer padding should not be applied with invalid token distan
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -4874,9 +4874,9 @@ exports[`Popover pointer padding should not be applied with invalid token distan
 exports[`Popover pointer padding should not be applied with non-px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -5077,9 +5077,9 @@ exports[`Popover pointer padding should not be applied with non-px distance over
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -5135,7 +5135,7 @@ exports[`Popover pointer padding should not be applied with non-px distance over
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -5144,9 +5144,9 @@ exports[`Popover pointer padding should not be applied with non-px distance over
 exports[`Popover should render correct styles: default 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -5332,9 +5332,9 @@ exports[`Popover should render correct styles: default 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -5395,9 +5395,9 @@ exports[`Popover should render correct styles: default 1`] = `
 exports[`Popover should render correct styles: with overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -5592,9 +5592,9 @@ exports[`Popover should render correct styles: with overrides 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -5655,9 +5655,9 @@ exports[`Popover should render correct styles: with overrides 1`] = `
 exports[`Popover should render correct styles: with pointer 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -5858,9 +5858,9 @@ exports[`Popover should render correct styles: with pointer 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -5916,7 +5916,7 @@ exports[`Popover should render correct styles: with pointer 1`] = `
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -5925,9 +5925,9 @@ exports[`Popover should render correct styles: with pointer 1`] = `
 exports[`Popover should render correct styles: with pointer size overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -6128,9 +6128,9 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -6186,7 +6186,7 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -6195,9 +6195,9 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
 exports[`Popover should render correct styles: with pointer stylePreset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -6398,9 +6398,9 @@ exports[`Popover should render correct styles: with pointer stylePreset override
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -6456,7 +6456,7 @@ exports[`Popover should render correct styles: with pointer stylePreset override
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -6465,9 +6465,9 @@ exports[`Popover should render correct styles: with pointer stylePreset override
 exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
 <DocumentFragment>
   <button
-    aria-controls="MOCK-ID"
+    aria-controls="floating-MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
+    id="ref-MOCK-ID"
     type="submit"
   >
     Add
@@ -6668,9 +6668,9 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
 
 <div
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
+    aria-labelledby="ref-MOCK-ID"
     class="emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="dialog"
     tabindex="-1"
   >
@@ -6726,7 +6726,7 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
     </div>
     <div
       class="emotion-10"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -24,11 +24,6 @@ exports[`Popover close button applies logical prop overrides 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -40,6 +35,11 @@ exports[`Popover close button applies logical prop overrides 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -293,11 +293,6 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -321,12 +316,22 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
   border-color: #CCCCCC;
   border-style: none none solid none;
   border-width: 1px;
+  font-family: "Poppins",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 16px;
 }
 
 .emotion-4 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -549,11 +554,6 @@ exports[`Popover close button should show left-aligned 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -565,6 +565,11 @@ exports[`Popover close button should show left-aligned 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -798,11 +803,6 @@ exports[`Popover close button should show right-aligned 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -814,6 +814,11 @@ exports[`Popover close button should show right-aligned 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -1049,11 +1054,6 @@ exports[`Popover content applies logical prop overrides 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -1065,6 +1065,11 @@ exports[`Popover content applies logical prop overrides 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 20px;
   padding-block: 24px;
 }
@@ -1294,6 +1299,287 @@ exports[`Popover content applies logical prop overrides 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Popover content applies stylePreset overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: header;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  font-family: "Poppins",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding-inline: 24px;
+  padding-block: 16px;
+}
+
+.emotion-4 {
+  grid-area: content;
+  color: #FFFFFF;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-5 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-6 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-6 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-6:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-6:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-6:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-6:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-9 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="header-text"
+        >
+          header value
+        </div>
+        <div
+          class="emotion-4"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-5"
+        >
+          <button
+            aria-label="close"
+            class="emotion-6"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-7"
+            >
+              <div
+                class="emotion-8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-9 emotion-10"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Popover header applies logical prop overrides 1`] = `
 <DocumentFragment>
   <button
@@ -1318,11 +1604,6 @@ exports[`Popover header applies logical prop overrides 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -1334,6 +1615,11 @@ exports[`Popover header applies logical prop overrides 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -1587,11 +1873,6 @@ exports[`Popover header applies stylePreset overrides 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -1615,12 +1896,22 @@ exports[`Popover header applies stylePreset overrides 1`] = `
   border-color: #CCCCCC;
   border-style: none none solid none;
   border-width: 1px;
+  font-family: "Poppins",sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 16px;
 }
 
 .emotion-4 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -1862,11 +2153,6 @@ exports[`Popover offset should be applied with pointer and px distance override 
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -1878,6 +2164,11 @@ exports[`Popover offset should be applied with pointer and px distance override 
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -2131,11 +2422,6 @@ exports[`Popover offset should be applied with pointer and token distance overri
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -2147,6 +2433,11 @@ exports[`Popover offset should be applied with pointer and token distance overri
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -2400,11 +2691,6 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -2416,6 +2702,11 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -2669,11 +2960,6 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -2685,6 +2971,11 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -2938,11 +3229,6 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -2954,6 +3240,11 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -3189,11 +3480,6 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -3205,6 +3491,11 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -3458,11 +3749,6 @@ exports[`Popover pointer padding should be applied with token distance override 
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -3474,6 +3760,11 @@ exports[`Popover pointer padding should be applied with token distance override 
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -3727,11 +4018,6 @@ exports[`Popover pointer padding should not be applied with invalid token distan
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -3743,6 +4029,11 @@ exports[`Popover pointer padding should not be applied with invalid token distan
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -3996,11 +4287,6 @@ exports[`Popover pointer padding should not be applied with non-px distance over
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -4012,6 +4298,11 @@ exports[`Popover pointer padding should not be applied with non-px distance over
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -4265,11 +4556,6 @@ exports[`Popover should render correct styles: default 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -4281,6 +4567,11 @@ exports[`Popover should render correct styles: default 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -4536,6 +4827,11 @@ exports[`Popover should render correct styles: with overrides 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 8px;
   padding-block: 16px;
 }
@@ -4771,11 +5067,6 @@ exports[`Popover should render correct styles: with pointer 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -4787,6 +5078,11 @@ exports[`Popover should render correct styles: with pointer 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -5040,11 +5336,6 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -5056,6 +5347,11 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -5309,11 +5605,6 @@ exports[`Popover should render correct styles: with pointer stylePreset override
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -5325,6 +5616,11 @@ exports[`Popover should render correct styles: with pointer stylePreset override
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }
@@ -5578,11 +5874,6 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
   color: #2E2E2E;
   border-radius: 8px;
   background-color: #FFFFFF;
-  font-family: "Poppins",sans-serif;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: 0;
 }
 
 .emotion-2 {
@@ -5594,6 +5885,11 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
 
 .emotion-3 {
   grid-area: content;
+  font-family: "DM Sans",sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+  letter-spacing: 0;
   padding-inline: 24px;
   padding-block: 24px;
 }

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -1,5 +1,1574 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Popover close button applies logical prop overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: -24px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 20px;
+  padding-block: 24px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  left: 12px;
+  bottom: calc(-16px / 2);
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-10"
+      id="MOCK-ID-pointer"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover close button applies stylePreset overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: header;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 24px;
+  padding-block: 16px;
+}
+
+.emotion-4 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-5 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #A60100;
+  border-style: solid;
+  border-width: 2px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: #A60100;
+  border-radius: 50%;
+  color: #FFFFFF;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-6 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-6 svg {
+  fill: #2E2E2E;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-9 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="header-text"
+        >
+          header value
+        </div>
+        <div
+          class="emotion-4"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-5"
+        >
+          <button
+            aria-label="close"
+            class="emotion-6"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-7"
+            >
+              <div
+                class="emotion-8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-9 emotion-10"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover close button should show left-aligned 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'close header' 'content content';
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-right: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover close button should show right-aligned 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover header applies logical prop overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: -24px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  left: 12px;
+  bottom: calc(-16px / 2);
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-10"
+      id="MOCK-ID-pointer"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Popover header applies stylePreset overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: header;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 24px;
+  padding-block: 16px;
+}
+
+.emotion-4 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-5 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-6 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-6 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-6:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-6:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-6:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-6:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-6 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-9 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-9 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+          data-testid="header-text"
+        >
+          header value
+        </div>
+        <div
+          class="emotion-4"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-5"
+        >
+          <button
+            aria-label="close"
+            class="emotion-6"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-7"
+            >
+              <div
+                class="emotion-8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-9 emotion-10"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Popover offset should be applied with pointer and px distance override 1`] = `
 <DocumentFragment>
   <button
@@ -29,11 +1598,167 @@ exports[`Popover offset should be applied with pointer and px distance override 
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -55,15 +1780,58 @@ exports[`Popover offset should be applied with pointer and px distance override 
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -99,11 +1867,167 @@ exports[`Popover offset should be applied with pointer and token distance overri
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -125,15 +2049,58 @@ exports[`Popover offset should be applied with pointer and token distance overri
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -169,11 +2136,167 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -195,15 +2318,58 @@ exports[`Popover offset should not be applied with pointer and invalid token dis
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -239,11 +2405,167 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -265,15 +2587,58 @@ exports[`Popover offset should not be applied with pointer and non-px distance o
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -309,8 +2674,164 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
 }
 
 <div
@@ -321,13 +2842,56 @@ exports[`Popover offset should not be applied with with no pointer 1`] = `
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -361,11 +2925,167 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -387,15 +3107,58 @@ exports[`Popover pointer padding should be applied with px distance override 1`]
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -431,11 +3194,167 @@ exports[`Popover pointer padding should be applied with token distance override 
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -457,15 +3376,58 @@ exports[`Popover pointer padding should be applied with token distance override 
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -501,11 +3463,167 @@ exports[`Popover pointer padding should not be applied with invalid token distan
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -527,15 +3645,58 @@ exports[`Popover pointer padding should not be applied with invalid token distan
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -571,11 +3732,167 @@ exports[`Popover pointer padding should not be applied with non-px distance over
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -597,15 +3914,58 @@ exports[`Popover pointer padding should not be applied with non-px distance over
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -641,8 +4001,164 @@ exports[`Popover should render correct styles: default 1`] = `
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
 }
 
 <div
@@ -653,13 +4169,56 @@ exports[`Popover should render correct styles: default 1`] = `
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -699,6 +4258,164 @@ exports[`Popover should render correct styles: with overrides 1`] = `
   padding-block: 16px;
 }
 
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 8px;
+  padding-block: 16px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
 <div
     aria-expanded="true"
     aria-labelledby="MOCK-ID"
@@ -707,13 +4424,56 @@ exports[`Popover should render correct styles: with overrides 1`] = `
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -747,11 +4507,167 @@ exports[`Popover should render correct styles: with pointer 1`] = `
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -773,15 +4689,58 @@ exports[`Popover should render correct styles: with pointer 1`] = `
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -817,11 +4776,167 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -843,15 +4958,58 @@ exports[`Popover should render correct styles: with pointer size overrides 1`] =
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -887,11 +5045,167 @@ exports[`Popover should render correct styles: with pointer stylePreset override
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -913,15 +5227,58 @@ exports[`Popover should render correct styles: with pointer stylePreset override
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>
@@ -957,11 +5314,167 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
   line-height: 1.5;
   font-weight: 500;
   letter-spacing: 0;
-  padding-inline: 16px;
-  padding-block: 16px;
 }
 
 .emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 24px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -983,15 +5496,58 @@ exports[`Popover should render correct styles: with pointer y coordinate 1`] = `
     role="dialog"
     tabindex="-1"
   >
-    <p
+    <div
       class="emotion-1"
       data-testid="floating-element-panel"
       tabindex="-1"
     >
-      hello
-    </p>
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
     <div
-      class="emotion-2"
+      class="emotion-10"
       id="MOCK-ID-pointer"
     />
   </div>

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -1025,6 +1025,275 @@ exports[`Popover close button should show right-aligned 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Popover content applies logical prop overrides 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="MOCK-ID"
+    aria-haspopup="dialog"
+    id="MOCK-ID"
+    type="submit"
+  >
+    Add
+  </button>
+  .emotion-0 {
+  box-shadow: 0 16px 24px 0 rgba(10,10,10,0.08);
+  border-radius: 8px;
+  z-index: 80;
+  position: absolute;
+  left: 0px;
+  top: -24px;
+}
+
+.emotion-1 {
+  margin: 0;
+  color: #2E2E2E;
+  border-radius: 8px;
+  background-color: #FFFFFF;
+  font-family: "Poppins",sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.emotion-2 {
+  display: grid;
+  grid-template-areas: 'header close' 'content content';
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
+}
+
+.emotion-3 {
+  grid-area: content;
+  padding-inline: 20px;
+  padding-block: 24px;
+}
+
+.emotion-4 {
+  grid-area: close;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  border-color: #CCCCCC;
+  border-style: none none solid none;
+  border-width: 1px;
+  padding-inline: 8px;
+  padding-block: 8px;
+  padding-left: 0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  padding: 12px;
+  cursor: default;
+  overflow: hidden;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border-radius: 50%;
+  color: #2E2E2E;
+  margin: 0;
+  cursor: pointer;
+}
+
+.emotion-5 svg {
+  width: 24px;
+  height: 24px;
+}
+
+.emotion-5 svg {
+  fill: #2E2E2E;
+}
+
+.emotion-5:hover:not(:disabled) {
+  background-color: #FAFAFA;
+}
+
+.emotion-5:active:not(:disabled) {
+  background-color: #F4F4F4;
+}
+
+.emotion-5:disabled {
+  background-color: transparent;
+  color: #C0C0C0;
+}
+
+.emotion-5:disabled svg {
+  fill: #C0C0C0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-5 {
+    transition-property: background-color;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-left: calc(-8px/2);
+  margin-right: calc(-8px/2);
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: calc(8px/2);
+  margin-right: calc(8px/2);
+}
+
+.emotion-8 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  fill: #2E2E2E;
+  vertical-align: unset;
+  display: inline-block;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 200ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .emotion-8 {
+    transition-property: fill;
+    transition-duration: 0ms;
+    transition-timing-function: cubic-bezier(0, 0, .5, 1);
+  }
+}
+
+.emotion-10 {
+  position: absolute;
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  box-sizing: border-box;
+  background-color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  left: 12px;
+  bottom: calc(-16px / 2);
+}
+
+<div
+    aria-expanded="true"
+    aria-labelledby="MOCK-ID"
+    class="emotion-0"
+    id="MOCK-ID"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="emotion-1"
+      data-testid="floating-element-panel"
+      tabindex="-1"
+    >
+      <div
+        class="emotion-2"
+      >
+        <div
+          class="emotion-3"
+        >
+          hello
+        </div>
+        <div
+          class="emotion-4"
+        >
+          <button
+            aria-label="close"
+            class="emotion-5"
+            data-testid="close-button"
+            type="button"
+          >
+            <div
+              class="emotion-6"
+            >
+              <div
+                class="emotion-7"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-8 emotion-9"
+                  fill="currentColor"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-10"
+      id="MOCK-ID-pointer"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Popover header applies logical prop overrides 1`] = `
 <DocumentFragment>
   <button

--- a/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -275,7 +275,6 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
   <button
     aria-controls="MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
     type="submit"
   >
     Add
@@ -466,8 +465,8 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
 }
 
 <div
+    aria-describedby="MOCK-ID"
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
     class="emotion-0"
     id="MOCK-ID"
     role="dialog"
@@ -484,6 +483,7 @@ exports[`Popover close button applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
+          id="MOCK-ID"
         >
           header value
         </div>
@@ -1306,7 +1306,6 @@ exports[`Popover content applies stylePreset overrides 1`] = `
   <button
     aria-controls="MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
     type="submit"
   >
     Add
@@ -1515,8 +1514,8 @@ exports[`Popover content applies stylePreset overrides 1`] = `
 }
 
 <div
+    aria-describedby="MOCK-ID"
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
     class="emotion-0"
     id="MOCK-ID"
     role="dialog"
@@ -1533,6 +1532,7 @@ exports[`Popover content applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
+          id="MOCK-ID"
         >
           header value
         </div>
@@ -1857,7 +1857,6 @@ exports[`Popover header applies logical prop overrides 1`] = `
   <button
     aria-controls="MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
     type="submit"
   >
     Add
@@ -2080,8 +2079,8 @@ exports[`Popover header applies logical prop overrides 1`] = `
 }
 
 <div
+    aria-describedby="MOCK-ID"
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
     class="emotion-0"
     id="MOCK-ID"
     role="dialog"
@@ -2098,6 +2097,7 @@ exports[`Popover header applies logical prop overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
+          id="MOCK-ID"
         >
           header value
         </div>
@@ -2156,7 +2156,6 @@ exports[`Popover header applies stylePreset overrides 1`] = `
   <button
     aria-controls="MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
     type="submit"
   >
     Add
@@ -2364,8 +2363,8 @@ exports[`Popover header applies stylePreset overrides 1`] = `
 }
 
 <div
+    aria-describedby="MOCK-ID"
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
     class="emotion-0"
     id="MOCK-ID"
     role="dialog"
@@ -2382,6 +2381,7 @@ exports[`Popover header applies stylePreset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
+          id="MOCK-ID"
         >
           header value
         </div>
@@ -2436,7 +2436,6 @@ exports[`Popover header applies typography preset overrides 1`] = `
   <button
     aria-controls="MOCK-ID"
     aria-haspopup="dialog"
-    id="MOCK-ID"
     type="submit"
   >
     Add
@@ -2659,8 +2658,8 @@ exports[`Popover header applies typography preset overrides 1`] = `
 }
 
 <div
+    aria-describedby="MOCK-ID"
     aria-expanded="true"
-    aria-labelledby="MOCK-ID"
     class="emotion-0"
     id="MOCK-ID"
     role="dialog"
@@ -2677,6 +2676,7 @@ exports[`Popover header applies typography preset overrides 1`] = `
         <div
           class="emotion-3"
           data-testid="header-text"
+          id="MOCK-ID"
         >
           header value
         </div>

--- a/src/popover/__tests__/popover.stories.tsx
+++ b/src/popover/__tests__/popover.stories.tsx
@@ -10,6 +10,7 @@ import {IconButton} from '../../icon-button';
 import {GridLayout} from '../../grid-layout';
 import {createTheme, ThemeProvider} from '../../theme';
 import {PopoverProps} from '../types';
+import {LinkStandalone} from '../../link';
 
 const getPlacementStyling = (placement: Placement) => {
   const [side, alignment = 'center'] = placement.split('-');
@@ -74,6 +75,20 @@ const myCustomTheme = createTheme({
           color: '{{colors.inkInverse}}',
         },
       },
+      popoverHeaderCustom: {
+        base: {
+          borderColor: '{{colors.black}}',
+          borderStyle: 'none none solid none',
+          borderWidth: '{{borders.borderWidth010}}',
+        },
+      },
+      popoverCloseButtonContainerCustom: {
+        base: {
+          borderColor: '{{colors.black}}',
+          borderStyle: 'none none solid none',
+          borderWidth: '{{borders.borderWidth010}}',
+        },
+      },
     },
   },
 });
@@ -85,8 +100,8 @@ const StyledPage = styled.div`
 const StyledContainer = styled.div`
   border: 1px solid red;
   background-color: #f7f7f7;
-  height: 220px;
-  width: 320px;
+  height: 260px;
+  width: 360px;
   padding: 5px;
   overflow: scroll;
 `;
@@ -103,11 +118,14 @@ const StyledScrollChild = styled.div<{visualTest?: boolean}>`
         }}
 `;
 
+const DEFAULT_CONTENT =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dictum justo id rutrum consectetur. Cras ultrices diam id dapibus viverra.';
+
 const PopoverWithBtn = (props: Partial<Omit<PopoverProps, 'children'>>) => (
   <Popover
-    header="Popover header"
-    content="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-    overrides={{maxWidth: '250px'}}
+    header="Popover Title"
+    content={DEFAULT_CONTENT}
+    overrides={{maxWidth: '300px'}}
     {...props}
   >
     <IconButton
@@ -137,8 +155,9 @@ const BoundedPopover = ({
   containerStyle?: CSSProperties;
 }) => {
   const boundaryRef = useUpdatedRef<HTMLDivElement>(null);
+  const style = containerStyle || getPlacementStyling('top');
   return (
-    <StyledContainer ref={boundaryRef} style={containerStyle}>
+    <StyledContainer ref={boundaryRef} style={style}>
       <PopoverWithBtn
         boundary={boundaryRef.current || undefined}
         fallbackBehaviour={[]}
@@ -170,7 +189,6 @@ const PopoverStyleOverrides = ({open}: {open?: boolean}) => (
     <StyledPage>
       <StorybookSubHeading>Popover - style overrides</StorybookSubHeading>
       <BoundedPopover
-        containerStyle={getPlacementStyling('top')}
         open={open}
         overrides={{
           maxWidth: '250px',
@@ -180,6 +198,12 @@ const PopoverStyleOverrides = ({open}: {open?: boolean}) => (
           },
           panel: {
             stylePreset: 'popoverPanelCustom',
+          },
+          header: {
+            stylePreset: 'popoverHeaderCustom',
+          },
+          closeButtonContainer: {
+            stylePreset: 'popoverCloseButtonContainerCustom',
           },
         }}
       />
@@ -228,54 +252,77 @@ const PopoverBehaviours = ({open}: {open?: boolean}) => (
   </StyledPage>
 );
 
-export const StoryPopoverDefault = () => (
+export const StoryPopoverDefault = (open = true) => (
   <StyledPage>
     <GridLayout columns={{xs: 'repeat(1, minmax(0, 1fr))'}} rowGap="20px">
       <div>
-        <StorybookSubHeading>String content</StorybookSubHeading>
-        <BoundedPopover containerStyle={getPlacementStyling('top')} />
+        <StorybookSubHeading>Close button on right</StorybookSubHeading>
+        <BoundedPopover open={open} />
+      </div>
+      <div>
+        <StorybookSubHeading>Close button on left</StorybookSubHeading>
+        <BoundedPopover open={open} closePosition="left" />
+      </div>
+      <div>
+        <StorybookSubHeading>No header or close button</StorybookSubHeading>
+        <BoundedPopover open={open} header={undefined} closePosition="none" />
+      </div>
+      <div>
+        <StorybookSubHeading>Header title overflow</StorybookSubHeading>
+        <BoundedPopover
+          open={open}
+          header="This is a popover header. Content is passed as string. Should be a long one so that the icon button is vertically centered."
+          containerStyle={{
+            ...getPlacementStyling('top'),
+            height: '330px',
+          }}
+        />
       </div>
       <div>
         <StorybookSubHeading>Interactive content</StorybookSubHeading>
         <BoundedPopover
-          containerStyle={getPlacementStyling('top')}
+          open={open}
+          containerStyle={{
+            ...getPlacementStyling('top'),
+            height: '330px',
+          }}
           content={
-            <Button
-              size="small"
-              onClick={() => {
-                // eslint-disable-next-line no-alert
-                alert('Button clicked');
-              }}
-              style={{width: '100%'}}
-            >
-              Click me
-            </Button>
+            <div>
+              <div>{DEFAULT_CONTENT}</div>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'end',
+                  paddingTop: '30px',
+                }}
+              >
+                <LinkStandalone href="/">Find out more</LinkStandalone>
+                <Button style={{marginLeft: '30px'}}>Continue</Button>
+              </div>
+            </div>
           }
         />
       </div>
       <div>
         <StorybookSubHeading>No pointer</StorybookSubHeading>
-        <BoundedPopover
-          containerStyle={getPlacementStyling('top')}
-          hidePointer
-        />
+        <BoundedPopover open={open} hidePointer />
       </div>
       <GridLayout columns={{xs: 'repeat(3, minmax(0, 1fr))'}}>
         <div>
           <StorybookSubHeading>Default distance</StorybookSubHeading>
-          <BoundedPopover containerStyle={getPlacementStyling('top')} />
+          <BoundedPopover open={open} />
         </div>
         <div>
           <StorybookSubHeading>Increased distance</StorybookSubHeading>
           <BoundedPopover
-            containerStyle={getPlacementStyling('top')}
+            open={open}
             overrides={{distance: 'space070', maxWidth: '250px'}}
           />
         </div>
         <div>
           <StorybookSubHeading>Decreased distance</StorybookSubHeading>
           <BoundedPopover
-            containerStyle={getPlacementStyling('top')}
+            open={open}
             overrides={{distance: 'space030', maxWidth: '250px'}}
           />
         </div>

--- a/src/popover/__tests__/popover.stories.tsx
+++ b/src/popover/__tests__/popover.stories.tsx
@@ -13,7 +13,7 @@ import {PopoverProps} from '../types';
 import {LinkStandalone} from '../../link';
 
 // Open all Popovers by default when running in Applitools.
-const isApplitoolsTest = process.env.APPLITOOLS_BATCH_ID !== undefined;
+const isApplitoolsTest = process.env.APPLITOOLS_BATCH_ID === undefined;
 
 const getPlacementStyling = (placement: Placement) => {
   const [side, alignment = 'center'] = placement.split('-');
@@ -75,7 +75,6 @@ const myCustomTheme = createTheme({
         base: {
           backgroundColor: '{{colors.red080}}',
           borderRadius: '{{borders.borderRadiusDefault}}',
-          color: '{{colors.inkInverse}}',
         },
       },
       popoverHeaderCustom: {
@@ -83,6 +82,7 @@ const myCustomTheme = createTheme({
           borderColor: '{{colors.black}}',
           borderStyle: 'none none solid none',
           borderWidth: '{{borders.borderWidth010}}',
+          color: '{{colors.inkInverse}}',
         },
       },
       popoverCloseButtonContainerCustom: {
@@ -90,6 +90,11 @@ const myCustomTheme = createTheme({
           borderColor: '{{colors.black}}',
           borderStyle: 'none none solid none',
           borderWidth: '{{borders.borderWidth010}}',
+        },
+      },
+      popoverContentCustom: {
+        base: {
+          color: '{{colors.inkInverse}}',
         },
       },
     },
@@ -314,7 +319,7 @@ export const StoryPopoverStyleOverrides = () => (
       <StorybookSubHeading>Popover - style overrides</StorybookSubHeading>
       <BoundedPopover
         overrides={{
-          maxWidth: '250px',
+          maxWidth: '300px',
           stylePreset: 'popoverCustom',
           pointer: {
             stylePreset: 'popoverPointerCustom',
@@ -327,6 +332,9 @@ export const StoryPopoverStyleOverrides = () => (
           },
           closeButtonContainer: {
             stylePreset: 'popoverCloseButtonContainerCustom',
+          },
+          content: {
+            stylePreset: 'popoverContentCustom',
           },
         }}
       />

--- a/src/popover/__tests__/popover.stories.tsx
+++ b/src/popover/__tests__/popover.stories.tsx
@@ -13,7 +13,7 @@ import {PopoverProps} from '../types';
 import {LinkStandalone} from '../../link';
 
 // Open all Popovers by default when running in Applitools.
-const isApplitoolsTest = process.env.APPLITOOLS_BATCH_ID === undefined;
+const isApplitoolsTest = process.env.APPLITOOLS_BATCH_ID !== undefined;
 
 const getPlacementStyling = (placement: Placement) => {
   const [side, alignment = 'center'] = placement.split('-');

--- a/src/popover/__tests__/popover.stories.tsx
+++ b/src/popover/__tests__/popover.stories.tsx
@@ -12,6 +12,9 @@ import {createTheme, ThemeProvider} from '../../theme';
 import {PopoverProps} from '../types';
 import {LinkStandalone} from '../../link';
 
+// Open all Popovers by default when running in Applitools.
+const isApplitoolsTest = process.env.APPLITOOLS_BATCH_ID !== undefined;
+
 const getPlacementStyling = (placement: Placement) => {
   const [side, alignment = 'center'] = placement.split('-');
   let alignItems;
@@ -106,11 +109,11 @@ const StyledContainer = styled.div`
   overflow: scroll;
 `;
 
-const StyledScrollChild = styled.div<{visualTest?: boolean}>`
+const StyledScrollChild = styled.div`
   height: 250px;
   width: 350px;
-  ${({visualTest = false}) =>
-    visualTest
+  ${() =>
+    isApplitoolsTest
       ? {}
       : {
           paddingTop: '180px',
@@ -121,8 +124,11 @@ const StyledScrollChild = styled.div<{visualTest?: boolean}>`
 const DEFAULT_CONTENT =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dictum justo id rutrum consectetur. Cras ultrices diam id dapibus viverra.';
 
-const PopoverWithBtn = (props: Partial<Omit<PopoverProps, 'children'>>) => (
+const PopoverWithBtn = (
+  props: Partial<Omit<PopoverProps, 'children' | 'open'>>,
+) => (
   <Popover
+    open={isApplitoolsTest || undefined}
     header="Popover Title"
     content={DEFAULT_CONTENT}
     overrides={{maxWidth: '300px'}}
@@ -151,7 +157,7 @@ function useUpdatedRef<T>(initialValue: T | null) {
 const BoundedPopover = ({
   containerStyle,
   ...popoverProps
-}: Partial<Omit<PopoverProps, 'children'>> & {
+}: Partial<Omit<PopoverProps, 'children' | 'open'>> & {
   containerStyle?: CSSProperties;
 }) => {
   const boundaryRef = useUpdatedRef<HTMLDivElement>(null);
@@ -167,54 +173,9 @@ const BoundedPopover = ({
   );
 };
 
-const PopoverPlacements = ({open}: {open?: boolean}) => (
-  <StyledPage>
-    <GridLayout columns={{xs: 'repeat(3, minmax(0, 1fr))'}} rowGap="20px">
-      {placements.map(placement => (
-        <div key={placement}>
-          <StorybookSubHeading>Popover - {placement}</StorybookSubHeading>
-          <BoundedPopover
-            containerStyle={getPlacementStyling(placement)}
-            open={open}
-            placement={placement}
-          />
-        </div>
-      ))}
-    </GridLayout>
-  </StyledPage>
-);
-
-const PopoverStyleOverrides = ({open}: {open?: boolean}) => (
-  <ThemeProvider theme={myCustomTheme}>
-    <StyledPage>
-      <StorybookSubHeading>Popover - style overrides</StorybookSubHeading>
-      <BoundedPopover
-        open={open}
-        overrides={{
-          maxWidth: '250px',
-          stylePreset: 'popoverCustom',
-          pointer: {
-            stylePreset: 'popoverPointerCustom',
-          },
-          panel: {
-            stylePreset: 'popoverPanelCustom',
-          },
-          header: {
-            stylePreset: 'popoverHeaderCustom',
-          },
-          closeButtonContainer: {
-            stylePreset: 'popoverCloseButtonContainerCustom',
-          },
-        }}
-      />
-    </StyledPage>
-  </ThemeProvider>
-);
-
 const BoundedPopoverWithOverflow = ({
   fallbackBehaviour,
-  open,
-}: Pick<PopoverProps, 'open' | 'fallbackBehaviour'>) => {
+}: Pick<PopoverProps, 'fallbackBehaviour'>) => {
   const boundaryRef = useUpdatedRef<HTMLDivElement>(null);
   return (
     <>
@@ -225,9 +186,8 @@ const BoundedPopoverWithOverflow = ({
           : `${(fallbackBehaviour || []).join(', ')}`}
       </StorybookSubHeading>
       <StyledContainer ref={boundaryRef}>
-        <StyledScrollChild visualTest={open}>
+        <StyledScrollChild>
           <PopoverWithBtn
-            open={open}
             fallbackBehaviour={fallbackBehaviour}
             content="Popover content"
             placement="top"
@@ -239,38 +199,36 @@ const BoundedPopoverWithOverflow = ({
   );
 };
 
-const PopoverBehaviours = ({open}: {open?: boolean}) => (
-  <StyledPage>
-    <GridLayout columns={{xs: 'repeat(1, minmax(0, 1fr))'}} rowGap="20px">
-      <BoundedPopoverWithOverflow open={open} fallbackBehaviour={['flip']} />
-      <BoundedPopoverWithOverflow open={open} fallbackBehaviour={['shift']} />
-      <BoundedPopoverWithOverflow
-        open={open}
-        fallbackBehaviour={['flip', 'shift']}
-      />
-    </GridLayout>
-  </StyledPage>
-);
-
-export const StoryPopoverDefault = (open = true) => (
+export const StoryPopoverDefault = () => (
   <StyledPage>
     <GridLayout columns={{xs: 'repeat(1, minmax(0, 1fr))'}} rowGap="20px">
       <div>
-        <StorybookSubHeading>Close button on right</StorybookSubHeading>
-        <BoundedPopover open={open} />
+        <StorybookSubHeading>
+          Popover - with optional header & close button on right
+        </StorybookSubHeading>
+        <BoundedPopover />
       </div>
       <div>
-        <StorybookSubHeading>Close button on left</StorybookSubHeading>
-        <BoundedPopover open={open} closePosition="left" />
+        <StorybookSubHeading>
+          Popover - with optional header & close button on left
+        </StorybookSubHeading>
+        <BoundedPopover closePosition="left" />
       </div>
       <div>
-        <StorybookSubHeading>No header or close button</StorybookSubHeading>
-        <BoundedPopover open={open} header={undefined} closePosition="none" />
+        <StorybookSubHeading>
+          Popover - no optional header & close button
+        </StorybookSubHeading>
+        <BoundedPopover header={undefined} closePosition="none" />
       </div>
       <div>
-        <StorybookSubHeading>Header title overflow</StorybookSubHeading>
+        <StorybookSubHeading>Popover - no pointer</StorybookSubHeading>
+        <BoundedPopover hidePointer />
+      </div>
+      <div>
+        <StorybookSubHeading>
+          Popover - header title overflow
+        </StorybookSubHeading>
         <BoundedPopover
-          open={open}
           header="This is a popover header. Content is passed as string. Should be a long one so that the icon button is vertically centered."
           containerStyle={{
             ...getPlacementStyling('top'),
@@ -279,9 +237,10 @@ export const StoryPopoverDefault = (open = true) => (
         />
       </div>
       <div>
-        <StorybookSubHeading>Interactive content</StorybookSubHeading>
+        <StorybookSubHeading>
+          Popover - example of other components passed to panel
+        </StorybookSubHeading>
         <BoundedPopover
-          open={open}
           containerStyle={{
             ...getPlacementStyling('top'),
             height: '330px',
@@ -303,26 +262,24 @@ export const StoryPopoverDefault = (open = true) => (
           }
         />
       </div>
-      <div>
-        <StorybookSubHeading>No pointer</StorybookSubHeading>
-        <BoundedPopover open={open} hidePointer />
-      </div>
       <GridLayout columns={{xs: 'repeat(3, minmax(0, 1fr))'}}>
         <div>
-          <StorybookSubHeading>Default distance</StorybookSubHeading>
-          <BoundedPopover open={open} />
+          <StorybookSubHeading>
+            Popover - distance (default)
+          </StorybookSubHeading>
+          <BoundedPopover />
         </div>
         <div>
-          <StorybookSubHeading>Increased distance</StorybookSubHeading>
+          <StorybookSubHeading>
+            Popover - distance (increased)
+          </StorybookSubHeading>
           <BoundedPopover
-            open={open}
             overrides={{distance: 'space070', maxWidth: '250px'}}
           />
         </div>
         <div>
-          <StorybookSubHeading>Decreased distance</StorybookSubHeading>
+          <StorybookSubHeading>Popover - distance (zero)</StorybookSubHeading>
           <BoundedPopover
-            open={open}
             overrides={{distance: 'space030', maxWidth: '250px'}}
           />
         </div>
@@ -331,43 +288,63 @@ export const StoryPopoverDefault = (open = true) => (
   </StyledPage>
 );
 StoryPopoverDefault.storyName = 'popover-default';
-StoryPopoverDefault.parameters = {
-  eyes: {include: false},
-};
 
-export const StoryPopoverPlacements = () => <PopoverPlacements />;
+export const StoryPopoverPlacements = () => (
+  <StyledPage>
+    <GridLayout columns={{xs: 'repeat(3, minmax(0, 1fr))'}} rowGap="20px">
+      {placements.map(placement => (
+        <div key={placement}>
+          <StorybookSubHeading>
+            Popover - placement {placement}
+          </StorybookSubHeading>
+          <BoundedPopover
+            containerStyle={getPlacementStyling(placement)}
+            placement={placement}
+          />
+        </div>
+      ))}
+    </GridLayout>
+  </StyledPage>
+);
 StoryPopoverPlacements.storyName = 'popover-placements';
-StoryPopoverPlacements.parameters = {
-  eyes: {include: false},
-};
 
-export const StoryPopoverStyleOverrides = () => <PopoverStyleOverrides />;
+export const StoryPopoverStyleOverrides = () => (
+  <ThemeProvider theme={myCustomTheme}>
+    <StyledPage>
+      <StorybookSubHeading>Popover - style overrides</StorybookSubHeading>
+      <BoundedPopover
+        overrides={{
+          maxWidth: '250px',
+          stylePreset: 'popoverCustom',
+          pointer: {
+            stylePreset: 'popoverPointerCustom',
+          },
+          panel: {
+            stylePreset: 'popoverPanelCustom',
+          },
+          header: {
+            stylePreset: 'popoverHeaderCustom',
+          },
+          closeButtonContainer: {
+            stylePreset: 'popoverCloseButtonContainerCustom',
+          },
+        }}
+      />
+    </StyledPage>
+  </ThemeProvider>
+);
 StoryPopoverStyleOverrides.storyName = 'popover-style-overrides';
-StoryPopoverStyleOverrides.parameters = {
-  eyes: {include: false},
-};
 
-export const StoryPopoverBehaviours = () => <PopoverBehaviours />;
+export const StoryPopoverBehaviours = () => (
+  <StyledPage>
+    <GridLayout columns={{xs: 'repeat(1, minmax(0, 1fr))'}} rowGap="20px">
+      <BoundedPopoverWithOverflow fallbackBehaviour={['flip']} />
+      <BoundedPopoverWithOverflow fallbackBehaviour={['shift']} />
+      <BoundedPopoverWithOverflow fallbackBehaviour={['flip', 'shift']} />
+    </GridLayout>
+  </StyledPage>
+);
 StoryPopoverBehaviours.storyName = 'popover-behaviours';
-StoryPopoverBehaviours.parameters = {
-  eyes: {include: false},
-};
-
-export const StoryPopoverStyleOverridesVisualTest = () => (
-  <PopoverStyleOverrides open />
-);
-StoryPopoverStyleOverridesVisualTest.storyName =
-  'popover-style-overrides-visual-test';
-
-export const StoryPopoverPlacementsVisualTest = () => (
-  <PopoverPlacements open />
-);
-StoryPopoverPlacementsVisualTest.storyName = 'popover-placements-visual-test';
-
-export const StoryPopoverBehavioursVisualTest = () => (
-  <PopoverBehaviours open />
-);
-StoryPopoverBehavioursVisualTest.storyName = 'popover-behaviours-visual-test';
 
 export default {
   title: 'NewsKit Light/popover',

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -445,17 +445,21 @@ describe('Popover', () => {
       const el = queryByRole('dialog');
       expect(el).toHaveAttribute('aria-expanded', 'true');
     });
-    test('floating element has default aria-labelledby', () => {
-      const {queryByRole, getByRole} = renderWithTheme(Popover, defaultProps);
+    test('floating element has default aria-labelledby if no header is passed', () => {
+      const {queryByRole, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        header: undefined,
+      });
       const btn = getByRole('button');
       fireEvent.click(btn);
       const el = queryByRole('dialog');
       expect(el).toHaveAttribute('aria-labelledby', MOCK_ID);
       expect(btn).toHaveAttribute('id', MOCK_ID);
     });
-    test('floating element has custom aria-labelledby', () => {
+    test('floating element has custom aria-labelledby if no header is passed', () => {
       const {queryByRole, getByRole} = renderWithTheme(Popover, {
         ...defaultProps,
+        header: undefined,
         children: (
           <button id="customId" type="submit">
             Add
@@ -465,6 +469,16 @@ describe('Popover', () => {
       fireEvent.click(getByRole('button'));
       const el = queryByRole('dialog');
       expect(el).toHaveAttribute('aria-labelledby', 'customId');
+    });
+    test('floating element has aria-describedby if header is passed', () => {
+      const {queryByRole, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        header: 'header value',
+      });
+      const btn = getByRole('button');
+      fireEvent.click(btn);
+      const el = queryByRole('dialog');
+      expect(el).toHaveAttribute('aria-describedby', MOCK_ID);
     });
     test('context element has aria-haspopup', () => {
       const {queryByRole} = renderWithTheme(Popover, defaultProps);

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -378,6 +378,35 @@ describe('Popover', () => {
       fireEvent.click(button);
       expect(queryByRole('dialog')).toBeInTheDocument();
     });
+    test('should be able to use handleCloseButtonClick to update parent state', () => {
+      const Component = () => {
+        const [open, setOpen] = React.useState(true);
+        return (
+          <>
+            <Popover
+              handleCloseButtonClick={() => setOpen(false)}
+              open={open}
+              content="hello"
+            >
+              <button type="submit">Add</button>
+            </Popover>
+            <Button
+              data-testid="outside-control"
+              onClick={() => setOpen(!open)}
+            >
+              External control
+            </Button>
+          </>
+        );
+      };
+
+      const {getByTestId, queryByRole} = renderWithTheme(Component);
+      const closeButton = getByTestId('close-button');
+
+      expect(queryByRole('dialog')).toBeInTheDocument();
+      fireEvent.click(closeButton);
+      expect(queryByRole('dialog')).not.toBeInTheDocument();
+    });
     test('should call onDismiss on close', () => {
       const onDismiss = jest.fn();
       const Component = () => {
@@ -763,11 +792,13 @@ describe('Popover', () => {
       await applyAsyncStyling();
       expect(asFragment()).toMatchSnapshot();
     });
-    test('should close popover and call onDismiss when close button clicked', () => {
+    test('should close popover and call onDismiss and handleCloseButtonClick when close button clicked', () => {
       const onDismiss = jest.fn();
+      const handleCloseButtonClick = jest.fn();
       const {getByRole, queryByRole, getByTestId} = renderWithTheme(Popover, {
         ...defaultProps,
         onDismiss,
+        handleCloseButtonClick,
       });
       fireEvent.click(getByRole('button'));
       expect(queryByRole('dialog')).toBeInTheDocument();
@@ -775,6 +806,7 @@ describe('Popover', () => {
       fireEvent.click(closeBtn);
       expect(queryByRole('dialog')).not.toBeInTheDocument();
       expect(onDismiss).toHaveBeenCalled();
+      expect(handleCloseButtonClick).toHaveBeenCalled();
     });
   });
 

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -761,4 +761,22 @@ describe('Popover', () => {
       expect(onDismiss).toHaveBeenCalled();
     });
   });
+
+  describe('content', () => {
+    test('applies logical prop overrides', async () => {
+      const {asFragment, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        hidePointer: false,
+        overrides: {
+          content: {
+            paddingBlock: '24px',
+            paddingInline: '20px',
+          },
+        },
+      });
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+  });
 });

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -650,10 +650,26 @@ describe('Popover', () => {
       const {asFragment, getByRole} = renderWithTheme(Popover, {
         ...defaultProps,
         hidePointer: false,
+        header: 'header value',
         overrides: {
           header: {
             paddingBlock: '24px',
             paddingInline: '20px',
+          },
+        },
+      });
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('applies typography preset overrides', async () => {
+      const {asFragment, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        hidePointer: false,
+        header: 'header value',
+        overrides: {
+          header: {
+            typographyPreset: 'utilityLabel010',
           },
         },
       });
@@ -801,6 +817,20 @@ describe('Popover', () => {
           content: {
             paddingBlock: '24px',
             paddingInline: '20px',
+          },
+        },
+      });
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('applies typography preset overrides', async () => {
+      const {asFragment, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        hidePointer: false,
+        overrides: {
+          content: {
+            typographyPreset: 'editorialParagraph020',
           },
         },
       });

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -763,6 +763,36 @@ describe('Popover', () => {
   });
 
   describe('content', () => {
+    test('applies stylePreset overrides', async () => {
+      const myCustomTheme = createTheme({
+        name: 'my-custom-popover-theme',
+        overrides: {
+          stylePresets: {
+            contentCustom: {
+              base: {
+                color: '{{colors.inkInverse}}',
+              },
+            },
+          },
+        },
+      });
+      const {asFragment, getByRole} = renderWithTheme(
+        Popover,
+        {
+          ...defaultProps,
+          header: 'header value',
+          overrides: {
+            content: {
+              stylePreset: 'contentCustom',
+            },
+          },
+        },
+        myCustomTheme,
+      );
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
     test('applies logical prop overrides', async () => {
       const {asFragment, getByRole} = renderWithTheme(Popover, {
         ...defaultProps,

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -747,13 +747,18 @@ describe('Popover', () => {
       await applyAsyncStyling();
       expect(asFragment()).toMatchSnapshot();
     });
-    test.skip('should show close popover when close button clicked', () => {
-      const {getByRole, getByTestId} = renderWithTheme(Popover, defaultProps);
+    test('should close popover and call onDismiss when close button clicked', () => {
+      const onDismiss = jest.fn();
+      const {getByRole, queryByRole, getByTestId} = renderWithTheme(Popover, {
+        ...defaultProps,
+        onDismiss,
+      });
       fireEvent.click(getByRole('button'));
-      expect(getByRole('dialog')).toBeInTheDocument();
+      expect(queryByRole('dialog')).toBeInTheDocument();
       const closeBtn = getByTestId('close-button');
       fireEvent.click(closeBtn);
-      expect(getByRole('dialog')).not.toBeInTheDocument();
+      expect(queryByRole('dialog')).not.toBeInTheDocument();
+      expect(onDismiss).toHaveBeenCalled();
     });
   });
 });

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -88,6 +88,10 @@ describe('Popover', () => {
               stylePreset: 'popoverPanelCustom',
               typographyPreset: 'utilityLabel020',
             },
+            content: {
+              paddingBlock: 'space040',
+              paddingInline: 'space020',
+            },
           },
         },
         myCustomTheme,
@@ -517,7 +521,7 @@ describe('Popover', () => {
       const input2 = getByTestId('input2');
       expect(input2).toHaveFocus();
     });
-    test('shifts to elements outside popover after elements within popover', () => {
+    test('shifts to close button then to elements outside popover after elements within popover', () => {
       const Component = () => (
         <>
           <Popover
@@ -539,6 +543,9 @@ describe('Popover', () => {
       userEvent.tab();
       const input1 = getByTestId('input1');
       expect(input1).toHaveFocus();
+      userEvent.tab();
+      const closeBtn = getByTestId('close-button');
+      expect(closeBtn).toHaveFocus();
       userEvent.tab();
       const input2 = getByTestId('input2');
       expect(input2).toHaveFocus();
@@ -585,6 +592,168 @@ describe('Popover', () => {
 
       const restoreFocus = getByTestId('restoreFocus');
       expect(restoreFocus).toHaveFocus();
+    });
+  });
+
+  describe('header', () => {
+    test('should show if passed', () => {
+      const {getByRole, queryByTestId} = renderWithTheme(Popover, {
+        ...defaultProps,
+        header: 'header value',
+      });
+      fireEvent.click(getByRole('button'));
+      const headerText = queryByTestId('header-text');
+      expect(headerText).toHaveTextContent('header value');
+    });
+    test('should not show if not passed', () => {
+      const {getByRole, queryByTestId} = renderWithTheme(Popover, {
+        ...defaultProps,
+        header: undefined,
+      });
+      fireEvent.click(getByRole('button'));
+      const headerText = queryByTestId('header-text');
+      expect(headerText).not.toBeInTheDocument();
+    });
+    test('applies stylePreset overrides', async () => {
+      const myCustomTheme = createTheme({
+        name: 'my-custom-popover-theme',
+        overrides: {
+          stylePresets: {
+            popoverHeaderCustom: {
+              base: {
+                borderColor: '{{colors.red080}}',
+                borderStyle: 'solid',
+                borderWidth: '{{borders.borderWidth020}}',
+              },
+            },
+          },
+        },
+      });
+      const {asFragment, getByRole} = renderWithTheme(
+        Popover,
+        {
+          ...defaultProps,
+          header: 'header value',
+          overrides: {
+            pointer: {
+              stylePreset: 'popoverHeaderCustom',
+            },
+          },
+        },
+        myCustomTheme,
+      );
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('applies logical prop overrides', async () => {
+      const {asFragment, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        hidePointer: false,
+        overrides: {
+          header: {
+            paddingBlock: '24px',
+            paddingInline: '20px',
+          },
+        },
+      });
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+  });
+
+  describe('close button', () => {
+    test('should not show if hidden', () => {
+      const {getByRole, queryByTestId} = renderWithTheme(Popover, {
+        ...defaultProps,
+        closePosition: 'none',
+      });
+      fireEvent.click(getByRole('button'));
+      const closeBtn = queryByTestId('close-button');
+      expect(closeBtn).not.toBeInTheDocument();
+    });
+    test('should show right-aligned', () => {
+      const {getByRole, asFragment} = renderWithTheme(Popover, {
+        ...defaultProps,
+        closePosition: 'right',
+      });
+      fireEvent.click(getByRole('button'));
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('should show left-aligned', () => {
+      const {getByRole, asFragment} = renderWithTheme(Popover, {
+        ...defaultProps,
+        closePosition: 'left',
+      });
+      fireEvent.click(getByRole('button'));
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('applies stylePreset overrides', async () => {
+      const myCustomTheme = createTheme({
+        name: 'my-custom-popover-theme',
+        overrides: {
+          stylePresets: {
+            closeButtonCustom: {
+              base: {
+                backgroundColor: '{{colors.red080}}',
+                borderRadius: '{{borders.borderRadiusCircle}}',
+                color: '{{colors.white}}',
+                iconColor: '{{colors.inkBase}}',
+              },
+            },
+            closeButtonContainerCustom: {
+              base: {
+                borderColor: '{{colors.red080}}',
+                borderStyle: 'solid',
+                borderWidth: '{{borders.borderWidth020}}',
+              },
+            },
+          },
+        },
+      });
+      const {asFragment, getByRole} = renderWithTheme(
+        Popover,
+        {
+          ...defaultProps,
+          header: 'header value',
+          overrides: {
+            closeButton: {
+              stylePreset: 'closeButtonCustom',
+            },
+            closeButtonContainer: {
+              stylePreset: 'closeButtonContainerCustom',
+            },
+          },
+        },
+        myCustomTheme,
+      );
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test('applies logical prop overrides', async () => {
+      const {asFragment, getByRole} = renderWithTheme(Popover, {
+        ...defaultProps,
+        hidePointer: false,
+        overrides: {
+          closeButtonContainer: {
+            paddingBlock: '24px',
+            paddingInline: '20px',
+          },
+        },
+      });
+      fireEvent.click(getByRole('button'));
+      await applyAsyncStyling();
+      expect(asFragment()).toMatchSnapshot();
+    });
+    test.skip('should show close popover when close button clicked', () => {
+      const {getByRole, getByTestId} = renderWithTheme(Popover, defaultProps);
+      fireEvent.click(getByRole('button'));
+      expect(getByRole('dialog')).toBeInTheDocument();
+      const closeBtn = getByTestId('close-button');
+      fireEvent.click(closeBtn);
+      expect(getByRole('dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -453,8 +453,8 @@ describe('Popover', () => {
       const btn = getByRole('button');
       fireEvent.click(btn);
       const el = queryByRole('dialog');
-      expect(el).toHaveAttribute('aria-labelledby', MOCK_ID);
-      expect(btn).toHaveAttribute('id', MOCK_ID);
+      expect(el).toHaveAttribute('aria-labelledby', `ref-${MOCK_ID}`);
+      expect(btn).toHaveAttribute('id', `ref-${MOCK_ID}`);
     });
     test('floating element has custom aria-labelledby if no header is passed', () => {
       const {queryByRole, getByRole} = renderWithTheme(Popover, {
@@ -478,7 +478,7 @@ describe('Popover', () => {
       const btn = getByRole('button');
       fireEvent.click(btn);
       const el = queryByRole('dialog');
-      expect(el).toHaveAttribute('aria-describedby', MOCK_ID);
+      expect(el).toHaveAttribute('aria-describedby', `header-${MOCK_ID}`);
     });
     test('context element has aria-haspopup', () => {
       const {queryByRole} = renderWithTheme(Popover, defaultProps);
@@ -489,7 +489,7 @@ describe('Popover', () => {
       const {getByRole} = renderWithTheme(Popover, defaultProps);
       const btn = getByRole('button');
       fireEvent.click(btn);
-      expect(btn).toHaveAttribute('aria-controls', MOCK_ID);
+      expect(btn).toHaveAttribute('aria-controls', `floating-${MOCK_ID}`);
     });
   });
 

--- a/src/popover/defaults.ts
+++ b/src/popover/defaults.ts
@@ -11,8 +11,23 @@ export default {
     panel: {
       stylePreset: 'popoverPanel',
       typographyPreset: 'utilityLabel010',
+    },
+    header: {
+      stylePreset: 'popoverHeader',
       paddingBlock: 'space040',
-      paddingInline: 'space040',
+      paddingInline: 'space050',
+    },
+    content: {
+      paddingBlock: 'space050',
+      paddingInline: 'space050',
+    },
+    closeButton: {
+      stylePreset: 'iconButtonMinimalSecondary',
+    },
+    closeButtonContainer: {
+      stylePreset: 'popoverCloseButtonContainer',
+      paddingBlock: 'space020',
+      paddingInline: 'space020',
     },
   },
 };

--- a/src/popover/defaults.ts
+++ b/src/popover/defaults.ts
@@ -10,14 +10,15 @@ export default {
     },
     panel: {
       stylePreset: 'popoverPanel',
-      typographyPreset: 'utilityLabel010',
     },
     header: {
       stylePreset: 'popoverHeader',
+      typographyPreset: 'utilityLabel030',
       paddingBlock: 'space040',
       paddingInline: 'space050',
     },
     content: {
+      typographyPreset: 'editorialParagraph010',
       paddingBlock: 'space050',
       paddingInline: 'space050',
     },

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -52,7 +52,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
       filterOutFalsyProperties(overrides.closeButton),
     ),
   };
-  const headerId = useId();
+  const headerId = `header-${useId()}`;
 
   const buildFloatingElementAriaAttributes: BuildAriaAttributesFn = ({
     floating: {open},

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   FloatingContext,
   useClick,
+  useId,
   useInteractions as floatingUiUseInteractions,
 } from '@floating-ui/react-dom-interactions';
 import {PopoverProps} from './types';
@@ -34,14 +35,6 @@ const buildContextAriaAttributes: BuildAriaAttributesFn = ({
   'aria-controls': open ? id : undefined,
 });
 
-const buildFloatingElementAriaAttributes: BuildAriaAttributesFn = ({
-  floating: {open},
-  ref: {id},
-}) => ({
-  'aria-expanded': open,
-  'aria-labelledby': id,
-});
-
 const ThemelessPopover: React.FC<PopoverProps> = ({
   children,
   content,
@@ -59,6 +52,17 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
       filterOutFalsyProperties(overrides.closeButton),
     ),
   };
+  const headerId = useId();
+
+  const buildFloatingElementAriaAttributes: BuildAriaAttributesFn = ({
+    floating: {open},
+    ref: {id},
+  }) => ({
+    'aria-expanded': open,
+    'aria-labelledby': header ? undefined : id,
+    'aria-describedby': header ? headerId : undefined,
+  });
+
   if (!content) {
     return children;
   }
@@ -70,6 +74,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
         <StyledPopoverInnerPanel closePosition={closePosition}>
           {header !== undefined && (
             <StyledPopoverHeader
+              id={headerId}
               data-testid="header-text"
               overrides={overrides}
             >

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -10,6 +10,19 @@ import defaults from './defaults';
 import stylePresets from './style-presets';
 import {BaseFloatingElement} from '../base-floating-element/base-floating-element';
 import {BuildAriaAttributesFn} from '../base-floating-element';
+import {IconButton} from '../icon-button';
+import {ButtonSize} from '../button';
+import {IconFilledClose} from '../icons';
+import {
+  StyledPopoverCloseButtonContainer,
+  StyledPopoverContent,
+  StyledPopoverHeader,
+  StyledDialogPanel,
+} from './styled';
+import {BreakpointKeys, useTheme} from '../theme';
+import {deepMerge} from '../utils';
+import {mergeBreakpointObject} from '../utils/merge-breakpoint-object';
+import {filterOutFalsyProperties} from '../utils/filter-object';
 
 const useInteractions = (context: FloatingContext<HTMLElement>) =>
   floatingUiUseInteractions([useClick(context)]);
@@ -32,20 +45,67 @@ const buildFloatingElementAriaAttributes: BuildAriaAttributesFn = ({
 const ThemelessPopover: React.FC<PopoverProps> = ({
   children,
   content,
+  header,
+  closePosition = 'right',
+  overrides = {},
   ...props
-}) => (
-  <BaseFloatingElement
-    path="popover"
-    content={content}
-    buildRefElAriaAttributes={buildContextAriaAttributes}
-    buildFloatingElAriaAttributes={buildFloatingElementAriaAttributes}
-    useInteractions={useInteractions}
-    role="dialog"
-    {...props}
-  >
-    {children}
-  </BaseFloatingElement>
-);
+}) => {
+  const theme = useTheme();
+  const closeButtonOverrides: typeof overrides['closeButton'] = {
+    ...deepMerge(
+      mergeBreakpointObject(Object.keys(theme.breakpoints) as BreakpointKeys[]),
+      theme.componentDefaults.popover.closeButton,
+      filterOutFalsyProperties(overrides.closeButton),
+    ),
+  };
+  if (!content) {
+    return children;
+  }
+
+  return (
+    <BaseFloatingElement
+      path="popover"
+      content={
+        <StyledDialogPanel closePosition={closePosition}>
+          {header !== undefined && (
+            <StyledPopoverHeader
+              data-testid="header-text"
+              overrides={overrides}
+            >
+              {header}
+            </StyledPopoverHeader>
+          )}
+          <StyledPopoverContent overrides={overrides}>
+            {content}
+          </StyledPopoverContent>
+          {closePosition !== 'none' && (
+            <StyledPopoverCloseButtonContainer
+              overrides={overrides}
+              closePosition={closePosition}
+            >
+              <IconButton
+                data-testid="close-button"
+                aria-label="close"
+                overrides={closeButtonOverrides}
+                size={ButtonSize.Medium}
+              >
+                <IconFilledClose />
+              </IconButton>
+            </StyledPopoverCloseButtonContainer>
+          )}
+        </StyledDialogPanel>
+      }
+      buildRefElAriaAttributes={buildContextAriaAttributes}
+      buildFloatingElAriaAttributes={buildFloatingElementAriaAttributes}
+      useInteractions={useInteractions}
+      role="dialog"
+      overrides={overrides}
+      {...props}
+    >
+      {children}
+    </BaseFloatingElement>
+  );
+};
 
 export const Popover = withOwnTheme(ThemelessPopover)({
   defaults,

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -48,6 +48,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
   header,
   closePosition = 'right',
   overrides = {},
+  handleCloseButtonClick,
   ...props
 }) => {
   const theme = useTheme();
@@ -84,7 +85,12 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
               closePosition={closePosition}
             >
               <IconButton
-                onClick={onClick}
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                  onClick(e);
+                  if (handleCloseButtonClick) {
+                    handleCloseButtonClick();
+                  }
+                }}
                 data-testid="close-button"
                 aria-label="close"
                 overrides={closeButtonOverrides}

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -17,7 +17,7 @@ import {
   StyledPopoverCloseButtonContainer,
   StyledPopoverContent,
   StyledPopoverHeader,
-  StyledDialogPanel,
+  StyledPopoverInnerPanel,
 } from './styled';
 import {BreakpointKeys, useTheme} from '../theme';
 import {deepMerge} from '../utils';
@@ -66,7 +66,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
     <BaseFloatingElement
       path="popover"
       content={({onClick}) => (
-        <StyledDialogPanel closePosition={closePosition}>
+        <StyledPopoverInnerPanel closePosition={closePosition}>
           {header !== undefined && (
             <StyledPopoverHeader
               data-testid="header-text"
@@ -94,7 +94,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
               </IconButton>
             </StyledPopoverCloseButtonContainer>
           )}
-        </StyledDialogPanel>
+        </StyledPopoverInnerPanel>
       )}
       buildRefElAriaAttributes={buildContextAriaAttributes}
       buildFloatingElAriaAttributes={buildFloatingElementAriaAttributes}

--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -65,7 +65,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
   return (
     <BaseFloatingElement
       path="popover"
-      content={
+      content={({onClick}) => (
         <StyledDialogPanel closePosition={closePosition}>
           {header !== undefined && (
             <StyledPopoverHeader
@@ -84,6 +84,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
               closePosition={closePosition}
             >
               <IconButton
+                onClick={onClick}
                 data-testid="close-button"
                 aria-label="close"
                 overrides={closeButtonOverrides}
@@ -94,7 +95,7 @@ const ThemelessPopover: React.FC<PopoverProps> = ({
             </StyledPopoverCloseButtonContainer>
           )}
         </StyledDialogPanel>
-      }
+      )}
       buildRefElAriaAttributes={buildContextAriaAttributes}
       buildFloatingElAriaAttributes={buildFloatingElementAriaAttributes}
       useInteractions={useInteractions}

--- a/src/popover/style-presets.ts
+++ b/src/popover/style-presets.ts
@@ -19,4 +19,18 @@ export default {
       backgroundColor: '{{colors.interface010}}',
     },
   },
+  popoverHeader: {
+    base: {
+      borderColor: '{{colors.neutral040}}',
+      borderStyle: 'none none solid none',
+      borderWidth: '{{borders.borderWidth010}}',
+    },
+  },
+  popoverCloseButtonContainer: {
+    base: {
+      borderColor: '{{colors.neutral040}}',
+      borderStyle: 'none none solid none',
+      borderWidth: '{{borders.borderWidth010}}',
+    },
+  },
 } as Record<string, StylePreset>;

--- a/src/popover/styled.tsx
+++ b/src/popover/styled.tsx
@@ -1,4 +1,4 @@
-import {getStylePreset, styled} from '../utils/style';
+import {getStylePreset, getTypographyPreset, styled} from '../utils/style';
 import {logicalProps} from '../utils/logical-properties';
 import {createCssGrid} from '../dialog/styled';
 import {PopoverProps} from './types';
@@ -15,11 +15,14 @@ export const StyledPopoverHeader = styled.div<Pick<PopoverProps, 'overrides'>>`
   align-items: center;
   box-sizing: border-box;
   ${getStylePreset('popover.header', 'header')}
+  ${getTypographyPreset('popover.header', 'header')}
   ${logicalProps('popover.header', 'header')}
 `;
 
 export const StyledPopoverContent = styled.div<Pick<PopoverProps, 'overrides'>>`
   grid-area: content;
+  ${getStylePreset('popover.content', 'content')}
+  ${getTypographyPreset('popover.content', 'content')}
   ${logicalProps('popover.content', 'content')}
 `;
 

--- a/src/popover/styled.tsx
+++ b/src/popover/styled.tsx
@@ -3,7 +3,7 @@ import {logicalProps} from '../utils/logical-properties';
 import {createCssGrid} from '../dialog/styled';
 import {PopoverProps} from './types';
 
-export const StyledDialogPanel = styled.div<
+export const StyledPopoverInnerPanel = styled.div<
   Pick<PopoverProps, 'closePosition'>
 >`
   ${({closePosition}) => createCssGrid({closePosition})}

--- a/src/popover/styled.tsx
+++ b/src/popover/styled.tsx
@@ -1,0 +1,37 @@
+import {getStylePreset, styled} from '../utils/style';
+import {logicalProps} from '../utils/logical-properties';
+import {createCssGrid} from '../dialog/styled';
+import {PopoverProps} from './types';
+
+export const StyledDialogPanel = styled.div<
+  Pick<PopoverProps, 'closePosition'>
+>`
+  ${({closePosition}) => createCssGrid({closePosition})}
+`;
+
+export const StyledPopoverHeader = styled.div<Pick<PopoverProps, 'overrides'>>`
+  display: flex;
+  grid-area: header;
+  align-items: center;
+  box-sizing: border-box;
+  ${getStylePreset('popover.header', 'header')}
+  ${logicalProps('popover.header', 'header')}
+`;
+
+export const StyledPopoverContent = styled.div<Pick<PopoverProps, 'overrides'>>`
+  grid-area: content;
+  ${logicalProps('popover.content', 'content')}
+`;
+
+export const StyledPopoverCloseButtonContainer = styled.div<
+  Pick<PopoverProps, 'closePosition' | 'overrides'>
+>`
+  grid-area: close;
+  align-self: center;
+  box-sizing: border-box;
+  height: 100%;
+  ${getStylePreset('popover.closeButtonContainer', 'closeButtonContainer')}
+  ${logicalProps('popover.closeButtonContainer', 'closeButtonContainer')}
+  ${({closePosition}) =>
+    closePosition === 'left' ? `padding-right: 0;` : `padding-left: 0;`}
+`;

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -12,9 +12,11 @@ export type PopoverProps = Omit<
   handleCloseButtonClick?: () => void;
   overrides?: FloatingElementProps['overrides'] & {
     header?: {
+      typographyPreset?: MQ<string>;
       stylePreset?: MQ<string>;
     } & LogicalPaddingProps;
     content?: {
+      typographyPreset?: MQ<string>;
       stylePreset?: MQ<string>;
     } & LogicalPaddingProps;
     closeButton?: {

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -1,3 +1,27 @@
+import React from 'react';
 import {FloatingElementProps} from '../base-floating-element';
+import {MQ} from '../utils';
+import {LogicalPaddingProps} from '../utils/logical-properties';
 
-export type PopoverProps = Omit<FloatingElementProps, 'trigger'>;
+export type PopoverProps = Omit<
+  FloatingElementProps,
+  'trigger' | 'overrides'
+> & {
+  closePosition?: 'left' | 'right' | 'none';
+  header?: React.ReactNode;
+  handleCloseButtonClick?: () => void;
+  overrides?: FloatingElementProps['overrides'] & {
+    header?: {
+      stylePreset?: MQ<string>;
+    } & LogicalPaddingProps;
+    content?: {
+      stylePreset?: MQ<string>;
+    } & LogicalPaddingProps;
+    closeButton?: {
+      stylePreset?: MQ<string>;
+    };
+    closeButtonContainer?: {
+      stylePreset?: MQ<string>;
+    } & LogicalPaddingProps;
+  };
+};

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -14,7 +14,9 @@ export type PopoverProps = Omit<
     header?: {
       stylePreset?: MQ<string>;
     } & LogicalPaddingProps;
-    content?: LogicalPaddingProps;
+    content?: {
+      stylePreset?: MQ<string>;
+    } & LogicalPaddingProps;
     closeButton?: {
       stylePreset?: MQ<string>;
     };

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -14,9 +14,7 @@ export type PopoverProps = Omit<
     header?: {
       stylePreset?: MQ<string>;
     } & LogicalPaddingProps;
-    content?: {
-      stylePreset?: MQ<string>;
-    } & LogicalPaddingProps;
+    content?: LogicalPaddingProps;
     closeButton?: {
       stylePreset?: MQ<string>;
     };

--- a/src/theme/__tests__/__snapshots__/theme.test.ts.snap
+++ b/src/theme/__tests__/__snapshots__/theme.test.ts.snap
@@ -1977,12 +1977,28 @@ Object {
     "typographyPreset": "editorialParagraph020",
   },
   "popover": Object {
+    "closeButton": Object {
+      "stylePreset": "iconButtonMinimalSecondary",
+    },
+    "closeButtonContainer": Object {
+      "paddingBlock": "space020",
+      "paddingInline": "space020",
+      "stylePreset": "popoverCloseButtonContainer",
+    },
+    "content": Object {
+      "paddingBlock": "space050",
+      "paddingInline": "space050",
+      "typographyPreset": "editorialParagraph010",
+    },
     "distance": "space050",
-    "panel": Object {
+    "header": Object {
       "paddingBlock": "space040",
-      "paddingInline": "space040",
+      "paddingInline": "space050",
+      "stylePreset": "popoverHeader",
+      "typographyPreset": "utilityLabel030",
+    },
+    "panel": Object {
       "stylePreset": "popoverPanel",
-      "typographyPreset": "utilityLabel010",
     },
     "pointer": Object {
       "edgeOffset": "space030",
@@ -4400,6 +4416,20 @@ Object {
     "base": Object {
       "borderRadius": "{{borders.borderRadiusDefault}}",
       "boxShadow": "{{shadows.shadow050}}",
+    },
+  },
+  "popoverCloseButtonContainer": Object {
+    "base": Object {
+      "borderColor": "{{colors.neutral040}}",
+      "borderStyle": "none none solid none",
+      "borderWidth": "{{borders.borderWidth010}}",
+    },
+  },
+  "popoverHeader": Object {
+    "base": Object {
+      "borderColor": "{{colors.neutral040}}",
+      "borderStyle": "none none solid none",
+      "borderWidth": "{{borders.borderWidth010}}",
     },
   },
   "popoverPanel": Object {

--- a/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tooltip offset should be applied with pointer and px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -47,7 +47,7 @@ exports[`Tooltip offset should be applied with pointer and px distance override 
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -60,7 +60,7 @@ exports[`Tooltip offset should be applied with pointer and px distance override 
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -69,7 +69,7 @@ exports[`Tooltip offset should be applied with pointer and px distance override 
 exports[`Tooltip offset should be applied with pointer and token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -113,7 +113,7 @@ exports[`Tooltip offset should be applied with pointer and token distance overri
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -126,7 +126,7 @@ exports[`Tooltip offset should be applied with pointer and token distance overri
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -135,7 +135,7 @@ exports[`Tooltip offset should be applied with pointer and token distance overri
 exports[`Tooltip offset should not be applied with pointer and invalid token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -179,7 +179,7 @@ exports[`Tooltip offset should not be applied with pointer and invalid token dis
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -192,7 +192,7 @@ exports[`Tooltip offset should not be applied with pointer and invalid token dis
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -201,7 +201,7 @@ exports[`Tooltip offset should not be applied with pointer and invalid token dis
 exports[`Tooltip offset should not be applied with pointer and non-px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -245,7 +245,7 @@ exports[`Tooltip offset should not be applied with pointer and non-px distance o
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -258,7 +258,7 @@ exports[`Tooltip offset should not be applied with pointer and non-px distance o
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -267,7 +267,7 @@ exports[`Tooltip offset should not be applied with pointer and non-px distance o
 exports[`Tooltip offset should not be applied with with no pointer 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -296,7 +296,7 @@ exports[`Tooltip offset should not be applied with with no pointer 1`] = `
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -314,7 +314,7 @@ exports[`Tooltip offset should not be applied with with no pointer 1`] = `
 exports[`Tooltip pointer padding should be applied with px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -358,7 +358,7 @@ exports[`Tooltip pointer padding should be applied with px distance override 1`]
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -371,7 +371,7 @@ exports[`Tooltip pointer padding should be applied with px distance override 1`]
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -380,7 +380,7 @@ exports[`Tooltip pointer padding should be applied with px distance override 1`]
 exports[`Tooltip pointer padding should be applied with token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -424,7 +424,7 @@ exports[`Tooltip pointer padding should be applied with token distance override 
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -437,7 +437,7 @@ exports[`Tooltip pointer padding should be applied with token distance override 
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -446,7 +446,7 @@ exports[`Tooltip pointer padding should be applied with token distance override 
 exports[`Tooltip pointer padding should not be applied with invalid token distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -490,7 +490,7 @@ exports[`Tooltip pointer padding should not be applied with invalid token distan
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -503,7 +503,7 @@ exports[`Tooltip pointer padding should not be applied with invalid token distan
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -512,7 +512,7 @@ exports[`Tooltip pointer padding should not be applied with invalid token distan
 exports[`Tooltip pointer padding should not be applied with non-px distance override 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -556,7 +556,7 @@ exports[`Tooltip pointer padding should not be applied with non-px distance over
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -569,7 +569,7 @@ exports[`Tooltip pointer padding should not be applied with non-px distance over
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -578,7 +578,7 @@ exports[`Tooltip pointer padding should not be applied with non-px distance over
 exports[`Tooltip should render correct styles: default 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -607,7 +607,7 @@ exports[`Tooltip should render correct styles: default 1`] = `
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -625,7 +625,7 @@ exports[`Tooltip should render correct styles: default 1`] = `
 exports[`Tooltip should render correct styles: with overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -656,7 +656,7 @@ exports[`Tooltip should render correct styles: with overrides 1`] = `
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -674,7 +674,7 @@ exports[`Tooltip should render correct styles: with overrides 1`] = `
 exports[`Tooltip should render correct styles: with pointer 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -718,7 +718,7 @@ exports[`Tooltip should render correct styles: with pointer 1`] = `
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -731,7 +731,7 @@ exports[`Tooltip should render correct styles: with pointer 1`] = `
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -740,7 +740,7 @@ exports[`Tooltip should render correct styles: with pointer 1`] = `
 exports[`Tooltip should render correct styles: with pointer size overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -784,7 +784,7 @@ exports[`Tooltip should render correct styles: with pointer size overrides 1`] =
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -797,7 +797,7 @@ exports[`Tooltip should render correct styles: with pointer size overrides 1`] =
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -806,7 +806,7 @@ exports[`Tooltip should render correct styles: with pointer size overrides 1`] =
 exports[`Tooltip should render correct styles: with pointer stylePreset overrides 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -850,7 +850,7 @@ exports[`Tooltip should render correct styles: with pointer stylePreset override
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -863,7 +863,7 @@ exports[`Tooltip should render correct styles: with pointer stylePreset override
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>
@@ -872,7 +872,7 @@ exports[`Tooltip should render correct styles: with pointer stylePreset override
 exports[`Tooltip should render correct styles: with pointer y coordinate 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="MOCK-ID"
+    aria-describedby="floating-MOCK-ID"
     type="submit"
   >
     Add
@@ -916,7 +916,7 @@ exports[`Tooltip should render correct styles: with pointer y coordinate 1`] = `
 <div
     aria-hidden="true"
     class="Tooltip emotion-0"
-    id="MOCK-ID"
+    id="floating-MOCK-ID"
     role="tooltip"
     tabindex="-1"
   >
@@ -929,7 +929,7 @@ exports[`Tooltip should render correct styles: with pointer y coordinate 1`] = `
     </p>
     <div
       class="emotion-2"
-      id="MOCK-ID-pointer"
+      id="floating-MOCK-ID-pointer"
     />
   </div>
 </DocumentFragment>

--- a/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/src/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Tooltip offset should be applied with pointer and px distance override 
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -95,6 +96,7 @@ exports[`Tooltip offset should be applied with pointer and token distance overri
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -160,6 +162,7 @@ exports[`Tooltip offset should not be applied with pointer and invalid token dis
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -225,6 +228,7 @@ exports[`Tooltip offset should not be applied with pointer and non-px distance o
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -337,6 +341,7 @@ exports[`Tooltip pointer padding should be applied with px distance override 1`]
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -402,6 +407,7 @@ exports[`Tooltip pointer padding should be applied with token distance override 
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -467,6 +473,7 @@ exports[`Tooltip pointer padding should not be applied with invalid token distan
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -532,6 +539,7 @@ exports[`Tooltip pointer padding should not be applied with non-px distance over
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -693,6 +701,7 @@ exports[`Tooltip should render correct styles: with pointer 1`] = `
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -758,6 +767,7 @@ exports[`Tooltip should render correct styles: with pointer size overrides 1`] =
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -823,6 +833,7 @@ exports[`Tooltip should render correct styles: with pointer stylePreset override
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
@@ -888,6 +899,7 @@ exports[`Tooltip should render correct styles: with pointer y coordinate 1`] = `
 }
 
 .emotion-2 {
+  z-index: -1;
   position: absolute;
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);


### PR DESCRIPTION
[PPDSC-2121](https://nidigitalsolutions.jira.com/browse/PPDSC-2121)

**What**

1. Background: add header and close button to Popover component
2. What did you do: added these elements to the Popover component following the CSS grid pattern used in the Dialog component; added tests and stories; removed duplicate Applitools stories and used environment variable to open Popovers. 

**I have done:**
- [x] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected

**Differences with spec**:
* Added `content` default and stylePreset
* Added `closeButtonContainer` default and stylePreset
* Added `handleCloseButtonClick` prop (following pattern from Dialog). This is required to Close the popover on close button click in the controlled case.
