### PR TITLE
fix(PPDSC-2392): revert utilityButton020 typography preset

### DIFF
--- a/site/components/__tests__/__snapshots__/site-header.test.tsx.snap
+++ b/site/components/__tests__/__snapshots__/site-header.test.tsx.snap
@@ -912,7 +912,7 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -2648,7 +2648,7 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -4378,7 +4378,7 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/__tests__/__snapshots__/site-header.test.tsx.snap
+++ b/site/components/__tests__/__snapshots__/site-header.test.tsx.snap
@@ -682,7 +682,13 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   align-items: center;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
+  .emotion-32 {
+    grid-template-columns: auto 1fr auto auto 80px;
+  }
+}
+
+@media screen and (min-width: 1440px) {
   .emotion-32 {
     grid-template-columns: 276px 1fr auto auto 80px;
   }
@@ -811,7 +817,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   min-height: 80px;
   width: 100%;
   padding: 12px 16px;
-  margin-inline: 10px;
   cursor: default;
   overflow: hidden;
   border: none;
@@ -827,7 +832,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   border-style: solid;
   margin: 0;
   cursor: pointer;
-  margin-inline: 10px;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -841,15 +845,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   text-align: center;
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -895,15 +900,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   }
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -949,7 +955,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   min-height: 80px;
   width: 100%;
   padding: 12px 16px;
-  margin-inline: 10px;
   cursor: default;
   overflow: hidden;
   border: none;
@@ -965,7 +970,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   border-style: solid;
   margin: 0;
   cursor: pointer;
-  margin-inline: 10px;
   -webkit-box-pack: center;
   -ms-flex-pack: center;
   -webkit-justify-content: center;
@@ -973,15 +977,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   text-align: center;
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-47 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-47 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -1027,15 +1032,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on a section wi
   }
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-47 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-47 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -2418,7 +2424,13 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   align-items: center;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
+  .emotion-32 {
+    grid-template-columns: auto 1fr auto auto 80px;
+  }
+}
+
+@media screen and (min-width: 1440px) {
   .emotion-32 {
     grid-template-columns: 276px 1fr auto auto 80px;
   }
@@ -2547,7 +2559,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   min-height: 80px;
   width: 100%;
   padding: 12px 16px;
-  margin-inline: 10px;
   cursor: default;
   overflow: hidden;
   border: none;
@@ -2563,7 +2574,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   border-style: solid;
   margin: 0;
   cursor: pointer;
-  margin-inline: 10px;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2577,15 +2587,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   text-align: center;
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -2631,15 +2642,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   }
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -2685,7 +2697,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   min-height: 80px;
   width: 100%;
   padding: 12px 16px;
-  margin-inline: 10px;
   cursor: default;
   overflow: hidden;
   border: none;
@@ -2701,7 +2712,6 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   border-style: solid;
   margin: 0;
   cursor: pointer;
-  margin-inline: 10px;
   -webkit-box-pack: center;
   -ms-flex-pack: center;
   -webkit-justify-content: center;
@@ -2709,15 +2719,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   text-align: center;
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-47 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-47 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -2763,15 +2774,16 @@ exports[`SiteHeader has first item highlighted (About) if we are on the /about s
   }
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-47 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-47 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -4154,7 +4166,13 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   align-items: center;
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
+  .emotion-32 {
+    grid-template-columns: auto 1fr auto auto 80px;
+  }
+}
+
+@media screen and (min-width: 1440px) {
   .emotion-32 {
     grid-template-columns: 276px 1fr auto auto 80px;
   }
@@ -4283,7 +4301,6 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   min-height: 80px;
   width: 100%;
   padding: 12px 16px;
-  margin-inline: 10px;
   cursor: default;
   overflow: hidden;
   border: none;
@@ -4299,7 +4316,6 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   border-style: solid;
   margin: 0;
   cursor: pointer;
-  margin-inline: 10px;
   -webkit-box-pack: center;
   -ms-flex-pack: center;
   -webkit-justify-content: center;
@@ -4307,15 +4323,16 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   text-align: center;
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 
@@ -4361,15 +4378,16 @@ exports[`SiteHeader has no highlighted items if we are on the homepage 1`] = `
   }
 }
 
-@media screen and (min-width: 1024px) and (max-width: 1439px) {
+@media screen and (min-width: 1440px) {
   .emotion-42 {
-    padding-inline: 3px;
+    margin-inline: 10px;
+    padding-inline: 16px;
   }
 }
 
-@media screen and (min-width: 1440px) {
+@media screen and (min-width: 1024px) and (max-width: 1439px) {
   .emotion-42 {
-    padding-inline: 16px;
+    padding-inline: 3px;
   }
 }
 

--- a/site/components/component-api/__tests__/__snapshots__/component-api.test.tsx.snap
+++ b/site/components/component-api/__tests__/__snapshots__/component-api.test.tsx.snap
@@ -1112,7 +1112,7 @@ exports[`ComponentAPI renders with props for multiple components 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/sidebar/__tests__/__snapshots__/sidebar-navigation.test.tsx.snap
+++ b/site/components/sidebar/__tests__/__snapshots__/sidebar-navigation.test.tsx.snap
@@ -373,7 +373,7 @@ exports[`Sidebar navigation should match snapshot with active link 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -975,7 +975,7 @@ exports[`Sidebar navigation should match snapshot with active link 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -1422,7 +1422,7 @@ exports[`Sidebar navigation should match snapshot with no active link 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -2228,7 +2228,7 @@ exports[`Sidebar navigation should render only routes under current section 1`] 
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -2757,7 +2757,7 @@ exports[`Sidebar navigation should render only routes under current section 1`] 
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/site/components/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -430,7 +430,7 @@ exports[`Sidebar renders correctly when closed 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -4202,7 +4202,7 @@ exports[`Sidebar renders correctly when closed 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -8120,7 +8120,7 @@ exports[`Sidebar renders correctly when open 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -11895,7 +11895,7 @@ exports[`Sidebar renders correctly when open 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/site-header.tsx
+++ b/site/components/site-header.tsx
@@ -130,7 +130,7 @@ const SiteHeader = React.forwardRef<HeaderRef, HeaderProps>(
           overrides={{
             stylePreset: 'linkTopNavigation',
             minHeight: '80px',
-            marginInline: '10px',
+            marginInline: {lg: '0', xl: '10px'},
             paddingInline: {lg: '3px', xl: '16px'},
           }}
         >
@@ -161,7 +161,10 @@ const SiteHeader = React.forwardRef<HeaderRef, HeaderProps>(
         </Visible>
         <Visible lg xl>
           <GridLayout
-            columns={{lg: '276px 1fr auto auto 80px'}}
+            columns={{
+              lg: 'auto 1fr auto auto 80px',
+              xl: '276px 1fr auto auto 80px',
+            }}
             columnGap="20px"
             alignItems="center"
             areas={{

--- a/site/components/table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/site/components/table/__tests__/__snapshots__/table.test.tsx.snap
@@ -483,7 +483,7 @@ exports[`Table renders links correctly 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -716,7 +716,7 @@ exports[`Table renders number values automatically if undefined 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/tabs-with-table/__tests__/__snapshots__/tabs-with-table.test.tsx.snap
+++ b/site/components/tabs-with-table/__tests__/__snapshots__/tabs-with-table.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`TabsWithTable renders with default data 1`] = `
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/components/tools/__tests__/__snapshots__/svg-previewer.test.tsx.snap
+++ b/site/components/tools/__tests__/__snapshots__/svg-previewer.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`SvgPreviewer should change theme colors correctly when selecting a diff
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -1003,7 +1003,7 @@ Object {
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -1372,7 +1372,7 @@ Object {
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;
@@ -1825,7 +1825,7 @@ exports[`SvgPreviewer should render correctly when receiving one svg data 1`] = 
   font-family: "Poppins",sans-serif;
   font-size: 14px;
   line-height: 21px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   padding: 0.5px 0px;
   display: inline-block;

--- a/site/theme/__tests__/__snapshots__/doc-theme.test.ts.snap
+++ b/site/theme/__tests__/__snapshots__/doc-theme.test.ts.snap
@@ -2412,7 +2412,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -4959,7 +4959,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -7509,7 +7509,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -10056,7 +10056,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -12606,7 +12606,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -15153,7 +15153,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -17703,7 +17703,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },
@@ -20250,7 +20250,7 @@ Object {
     "utilityButton020": Object {
       "fontFamily": "{{fonts.fontFamily030.fontFamily}}",
       "fontSize": "{{fonts.fontSize020}}",
-      "fontWeight": "{{fonts.fontWeight020}}",
+      "fontWeight": "{{fonts.fontWeight030}}",
       "letterSpacing": "{{fonts.fontLetterSpacing030}}",
       "lineHeight": "{{fonts.fontLineHeight040}}",
     },

--- a/site/theme/typography-presets.json
+++ b/site/theme/typography-presets.json
@@ -86,6 +86,9 @@
   "utilityButton010": {
     "fontWeight": "{{fonts.fontWeight030}}"
   },
+  "utilityButton020": {
+    "fontWeight": "{{fonts.fontWeight030}}"
+  },
   "utilityButton030": {
     "fontWeight": "{{fonts.fontWeight030}}"
   },


### PR DESCRIPTION
PPDSC-2392

**What**

The `utilityButton020` typography preset was deleted incorrectly in the update theme task #345 😬 

This PR reverts the deleted typography preset.

Also as addition to this, on LG 1024px viewport screen the theme switch button is pushed out of the screen because of the #337 updates. This is now handled as well.

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
