### PR TITLE
build(PPDSC-2404): add version back into image name for dev deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,7 +785,7 @@ jobs:
             if [ << parameters.docker_version >> = release ]; then
               export DOCKER_TAG=$(node -p "require('./package.json').version")
             else
-              export DOCKER_TAG=${CIRCLE_SHA1}
+              export DOCKER_TAG=$(node -p "require('./package.json').version")-$CIRCLE_SHA1
             fi
             export AWS_ACCESS_KEY_ID=<< parameters.aws_access_key_id >>
             export AWS_SECRET_ACCESS_KEY=<< parameters.aws_secret_key >>


### PR DESCRIPTION
PPDSC-2404

**What**

1. Background - why this is needed, develop env deploy is broken
2. What did you do - added version back in for image name that pushed to ECS
3. What does the reviewers should expect - both ECS and flux should have version and has in the image name

