### PR TITLE
chore(PPDSC-2280): chore-ppdse-2280-added prevent default

### DIFF
--- a/src/consent/consent-settings-link.tsx
+++ b/src/consent/consent-settings-link.tsx
@@ -52,6 +52,7 @@ export const ConsentSettingsLink: React.FC<ConsentSettingsLinkProps> = ({
     href="#"
     role="button"
     onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
       try {
         if (gdpr) {
           // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
PPDSC-2280

**What**

1. Background - If you are on a page on the website that is not the homepage and  you click privacy policy link in the footer section it goes back to homepage and the privacy policy modal does not load. The ticket suggested that the href should be updated to whatever page the user is on when they click the pp modal. However I found this did not work.  I tried the below example
```
<LinkStandalone
    {...props}
    href="components/overview"
    role="button"
```
this had some weird behaviour the pp modal would show but the page would then refresh and go to `"components/overview"` and the PP modal would disappear.
I found that the href being passed in the `LinkStandlone `component was the problem. I did some research and ended up adding  ` event.preventDefault();` this stops the page from refreshing when and just displays the PP modal as expected whatever page i am on in the site.


4. What does the reviewers should expect- to test this locally i went to `_document.tsx` and commented out the line below. I think in order to test you might have to do the same 

<img width="736" alt="Screenshot 2022-09-08 at 12 45 08" src="https://user-images.githubusercontent.com/54642337/189113968-513553ba-c859-49b1-b4df-278c23ca1270.png">


<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
