### PR TITLE
docs(PPDSC-2545): copy updates to guide pages

### DIFF
--- a/site/pages/getting-started/code/engineering-overview.tsx
+++ b/site/pages/getting-started/code/engineering-overview.tsx
@@ -39,7 +39,7 @@ const PRINCIPLE_CARDS = [
     title: 'Accessible',
     description: (
       <>
-        NewsKit components folllow{' '}
+        NewsKit components follow{' '}
         <Link
           overrides={{stylePreset: 'inkWhiteContrast'}}
           href="https://www.w3.org/WAI/standards-guidelines/wcag/"

--- a/site/pages/getting-started/code/engineering-quickstart.tsx
+++ b/site/pages/getting-started/code/engineering-quickstart.tsx
@@ -19,15 +19,13 @@ const whatNextCards = [
   {
     media: getIllustrationComponent('theme/creating-a-theme/hero'),
     title: 'Creating a theme',
-    description:
-      'Themes represent the brand’s identity, controlling the appearance of all NewsKit components.',
+    description: 'Theme NewsKit components to match your brand.',
     href: '/theme/theming/creating-a-theme/',
   },
   {
     media: getIllustrationComponent('theme/using-a-theme/hero'),
     title: 'Using a theme',
-    description:
-      'To render NewsKit components you must have a theme available for them to utilise.',
+    description: 'Render NewsKit components using an available theme.',
     href: '/theme/theming/using-a-theme/',
   },
 ];
@@ -36,8 +34,7 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
   <GuidePageTemplate
     headTags={{
       title: 'Engineering quickstart',
-      description:
-        'This page describes how to get started building a web application with NewsKit.',
+      description: 'Start building digital products with NewsKit.',
     }}
     layoutProps={layoutProps}
     pageIntroduction={{
@@ -46,7 +43,7 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
       hero: {
         illustration: 'guides/engineering-quickstart/hero',
       },
-      introduction: `This page describes how to get started building a web application with NewsKit.`,
+      introduction: `Start building digital products with NewsKit.`,
     }}
     featureCard={{
       title: 'Need help?',
@@ -55,12 +52,12 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
     }}
   >
     <ComponentPageCell>
-      <ContentSection sectionName="prerequisites">
+      <ContentSection sectionName="Requirements">
         <ContentPrimary
-          id="prerequisites"
-          toc="Prerequisites"
-          headline="Prerequisites"
-          description="To start using NewsKit components in your projects you will need the following:"
+          id="Requirements"
+          toc="Requirements"
+          headline="Requirements"
+          description="To use NewsKit components in your project, you’ll need:"
           childrenColSpan={ContentColSpan.TEXT}
         >
           <UnorderedList
@@ -79,7 +76,7 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
               <Link href="https://nodejs.org/en/download/" target="_blank">
                 Node.js
               </Link>{' '}
-              with a minimum of node v14 installed.
+              v14 or newer.
             </>
             <>
               A project to install NewsKit into. If you need to create a new one
@@ -104,11 +101,11 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
 
         <ContentSecondary childrenColSpan={ContentColSpan.TEXT} showSeparator>
           <InlineMessage>
-            It’s recommended to use{' '}
+            We recommend{' '}
             <Link href="https://www.typescriptlang.org/" target="_blank">
               typescript
             </Link>
-            , but NewsKit will work with vanilla javascript too.
+            , but NewsKit works with vanilla javascript too.
           </InlineMessage>
         </ContentSecondary>
       </ContentSection>
@@ -120,7 +117,7 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
           headline="Install the package"
           description={
             <>
-              You can install NewsKit package using a package manager like{' '}
+              Install the NewsKit package using a package manager like{' '}
               <Link
                 href="https://docs.npmjs.com/cli/v8/commands/npm"
                 target="_blank"
@@ -154,23 +151,23 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
         </ContentPrimary>
       </ContentSection>
 
-      <ContentSection sectionName="setting up an app">
+      <ContentSection sectionName="set up an app">
         <ContentPrimary
-          id="settingupanapp"
-          toc="Setting up an app"
-          headline="Setting up an app"
+          id="setupanapp"
+          toc="Set up an app"
+          headline="Set up an app"
           description={
             <>
-              NewsKit components can be used like any typical{' '}
+              NewsKit components can be used like any{' '}
               <Link
                 href="https://reactjs.org/docs/components-and-props.html"
                 target="_blank"
               >
-                react components
+                React components
               </Link>
-              . One thing to bear in mind is that they will need to be
-              descendants of a <InlineCode>NewsKitProvider</InlineCode> which
-              provides a single wrapper to configure your application. It adds a{' '}
+              . They need to be descendants of a{' '}
+              <InlineCode>NewsKitProvider</InlineCode> which provides a single
+              wrapper to configure your application. It adds a{' '}
               <Link href="/theme/theming/using-a-theme/">ThemeProvider</Link>,{' '}
               <Link href="/components/utils/hooks/#usemediaqueryobject">
                 MediaQueryProvider
@@ -183,10 +180,9 @@ const EngineeringQuickstart = (layoutProps: LayoutProps) => (
               instrumentation and stacking context in the application.
               <br />
               <br />
-              The following example shows the &quot;Hello World!&quot; example
-              of using a NewsKit{' '}
-              <Link href="/components/tag/">Tag component</Link> with the
-              NewsKitProvider.
+              Here&apos;s the &quot;Hello World!&quot; example of using a
+              NewsKit <Link href="/components/tag/">Tag component</Link> with
+              the NewsKitProvider.
             </>
           }
           showSeparator
@@ -220,7 +216,7 @@ export default class App extends React.Component {
           id="whatsnext"
           toc="What’s next?"
           headline="What’s next?"
-          description="Want to use NewsKit for your next product? Follow the next steps belows to learn more:"
+          description=""
           showSeparator
         >
           <MediaList

--- a/site/pages/getting-started/code/instrumentation.tsx
+++ b/site/pages/getting-started/code/instrumentation.tsx
@@ -60,8 +60,7 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
   <GuidePageTemplate
     headTags={{
       title: 'Instrumentation setup',
-      description:
-        'This page describes how to setup instrumentation on NewsKit components',
+      description: 'Set up instrumentation on NewsKit components.',
     }}
     layoutProps={layoutProps}
     pageIntroduction={{
@@ -70,7 +69,7 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
       hero: {
         illustration: 'guides/instrumentation-setup-hero',
       },
-      introduction: `This page describes how to setup instrumentation on NewsKit components`,
+      introduction: `Set up instrumentation on NewsKit components.`,
     }}
     featureCard={{
       title: 'Need help?',
@@ -84,40 +83,60 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
           id="overview"
           toc="Overview"
           headline="Overview"
+          showSeparator
+          childrenColSpan={ContentColSpan.TEXT}
           description={
             <>
               NewsKit components are built to emit events &quot;out of the
               box&quot; via the provided NewsKit event instrumentation system.
-              This system requires a small amount of setup in your project to
-              allow the emitted events to reach your desired tag manager. Events
-              fired via the provided instrumentation system can be forwarded to
-              as many &quot;handlers&quot; as desired. NewsKit provides two
-              handlers; a console handler that outputs the fired events to the
-              browser console, and a Tealium handler that forwards the event
-              onto the Tealium tag manager (Tealium must be present on the page
-              for this handler to work). You can also create your own handlers,
-              for example, if you require forwarding events to a different tag
-              manager.
+              This requires a small amount of setup in your project so emitted
+              events can reach your desired tag manager.
               <br />
               <br />
-              As well as the above handlers, NewsKit also provides a middleware
-              composition system to allow for operations on events before they
-              reach a handler. For example, if you wanted to filter events to
-              forward only a specific set to a tag manager, perform some event
-              data transformations, or batch the events reaching a handler.
+              Events fired via the provided instrumentation system can be
+              forwarded to as many handlers as desired. NewsKit provides two
+              handlers:
+              <br />
+              <UnorderedList
+                markerAlign="start"
+                overrides={{
+                  spaceStack: 'space050',
+                  marginBlockStart: 'space050',
+                  marker: {
+                    spaceInline: 'space020',
+                  },
+                  content: contentOverrides,
+                }}
+              >
+                <>
+                  A console handler that outputs the fired events to the browser
+                  console
+                </>
+                <>
+                  A Tealium handler that forwards the event onto the Tealium tag
+                  manager (Tealium must be present on the page for this handler
+                  to work)
+                </>
+              </UnorderedList>
+              The handlers are exported under{' '}
+              <InlineCode>instrumentationHandlers</InlineCode>. You can also
+              create your own handlers (e.g. if you need to forward events to a
+              different tag manager).
+              <InlineMessage
+                role="region"
+                aria-label="Github"
+                overrides={{marginBlockStart: 'space070'}}
+              >
+                For more information, users with the relevant access can read
+                the internal RFC which lead to this implementation. This can be
+                found on{' '}
+                <Link href="https://github.com/newsuk/nuk-rfcs" target="_blank">
+                  Github.
+                </Link>
+              </InlineMessage>
             </>
           }
-          showSeparator
-          childrenColSpan={ContentColSpan.TEXT}
-        >
-          <InlineMessage role="region" aria-label="Github">
-            For more information, users with the relevant access can read the
-            internal RFC which lead to this implementation. This can be found on{' '}
-            <Link href="https://github.com/newsuk/nuk-rfcs" target="_blank">
-              Github.
-            </Link>
-          </InlineMessage>
-        </ContentPrimary>
+        />
       </ContentSection>
 
       <ContentSection sectionName="setup">
@@ -127,11 +146,13 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
           headline="Setup"
           description={
             <>
-              The event instrumentation system is part of NewsKit, so the same
-              regular install you have for other components is sufficient. The
-              first step is to create the event instrumentation by calling the
-              function; <InlineCode>createEventInstrumentation</InlineCode>.
-              This function takes two arguments;
+              The event instrumentation system is part of NewsKit, so the
+              install you have for other components works here, too.
+              <br />
+              <br />
+              Create the event instrumentation by calling the function{' '}
+              <InlineCode>createEventInstrumentation</InlineCode>. This takes
+              two arguments:
             </>
           }
           childrenColSpan={ContentColSpan.TEXT}
@@ -154,17 +175,17 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
               ), but you can also pass your own custom handlers.
             </>
             <>
-              an event context object; this is an optional, but recommended,
+              An event context object; this is an optional, but recommended,
               object of contextual data relevant to the page the events are
-              being fired from. It might contain for example the page URL and a
-              user identifier.
+              being fired from. It might contain, for example, the page URL and
+              a user identifier.
             </>
           </UnorderedList>
           <P overrides={contentOverrides}>
             This function will return an object containing the context passed to
             it and the <InlineCode>fireEvent</InlineCode> function. This is the
-            function that is used internally by the NewsKit components to fire
-            events to your handlers.
+            function used internally by NewsKit components to fire events to
+            your handlers.
           </P>
         </ContentPrimary>
 
@@ -179,18 +200,21 @@ const InstrumentationSetup = (layoutProps: LayoutProps) => (
               to set the components theme, NewsKit provides a React context
               component called <InlineCode>InstrumentationProvider</InlineCode>{' '}
               to wrap the React DOM of your project and provide the required
-              event instrumentation down to NewsKit components. The props
-              required for this component match the object output from the{' '}
-              <InlineCode>createEventInstrumentation</InlineCode> function and
-              as a result, the object can simply be destructured into the props
+              event instrumentation down to NewsKit components.
+              <br />
+              <br />
+              The props required for this component match the object output from
+              the <InlineCode>createEventInstrumentation</InlineCode> function.
+              As a result, the object can simply be destructured into the props
               of the provider.
             </>
           }
         >
           <InlineMessage overrides={{marginBlockEnd: 'space080'}}>
             Keep in mind that <InlineCode>NewsKitProvider</InlineCode> already
-            contains <InlineCode>InstrumentationProvider</InlineCode> so use it
-            only when want to create a new context for part of your application.
+            contains <InlineCode>InstrumentationProvider</InlineCode> so only
+            use it when you want to create a new context for part of your
+            application.
           </InlineMessage>
           <Code>
             {`import {
@@ -219,7 +243,7 @@ const MyPage = (
 );`}
           </Code>
         </ContentSecondary>
-        <ContentSecondary description="In this example, the Link component, and any other NewsKit instrumentation enabled components would emit events to the browser's console. This could look something like this:">
+        <ContentSecondary description="In this example, the link component, and any other NewsKit instrumentation enabled components, emit events to the browser's console. This could look something like this:">
           <Code>
             {`{
   "originator": "link",
@@ -232,7 +256,7 @@ const MyPage = (
         </ContentSecondary>
 
         <ContentSecondary
-          description="InstrumentationProvider components can be nested if you wish to extend the context object to add extra data. See the relevant section below for more information and examples."
+          description="InstrumentationProvider components can be nested if you wish to extend the context object to add extra data. See below for more information and examples."
           childrenColSpan={ContentColSpan.TEXT}
         />
 
@@ -240,20 +264,22 @@ const MyPage = (
           headline="Middleware"
           description={
             <>
-              NewsKit also contains a middleware composition system to allow for
+              NewsKit contains a middleware composition system to allow for
               operations on events before they reach a handler. For example, if
-              you wanted to filter events to forward only a specific set to a
-              tag manager, perform some event data transformations, or batch the
-              events reaching a handler. Instrumentation middleware functions
-              have the same signature as handlers; they take in an array of
-              events and must return an array of events. The returned array can
-              be a different length or even empty if necessary, though it is
-              recommended that middleware functions are pure and do not mutate
-              the array or events.
+              you want to filter events to forward only a specific set to a tag
+              manager, perform some event data transformations or batch the
+              events reaching a handler.
               <br />
               <br />
-              In the example below, filter middleware is used to pass only
-              specific events to specific handlers.
+              Instrumentation middleware functions have the same signature as
+              handlers. They take in an array of events and must return an array
+              of events. The returned array can be a different length - or even
+              empty, if necessary - though it&apos;s recommended that middleware
+              functions are pure and do not mutate the array or events.
+              <br />
+              <br />
+              The example below uses filter middleware to pass only specific
+              events to specific handlers:
             </>
           }
         >
@@ -295,7 +321,7 @@ const instrumentation = createEventInstrumentation(handlers, {
 
         <ContentSecondary
           headline="Custom Event Firing"
-          description="You should not need to add any instrumentation event firing to NewsKit components as this is already provided, but there may be a case where you have pre-existing custom components and wish to utilise the single NewsKit event instrumentation. This can be done easily in two ways;"
+          description="You shouldn't need to add instrumentation event firing to NewsKit components, as this is already provided. But there may be a case where you have pre-existing custom components and wish to use the single NewsKit event instrumentation. You can do this in two ways:"
           childrenColSpan={ContentColSpan.TEXT}
         >
           <UnorderedList
@@ -309,25 +335,30 @@ const instrumentation = createEventInstrumentation(handlers, {
             }}
           >
             <>
-              using the NewsKit HOC <InlineCode>withInstrumentation</InlineCode>
-              . This will wrap the component argument in the instrumentation
-              context and a <InlineCode>fireEvent</InlineCode> prop will be
-              passed to the component.
+              Use the NewsKit HOC <InlineCode>withInstrumentation</InlineCode>.
+              This wraps the component argument in the instrumentation context
+              and passes a <InlineCode>fireEvent</InlineCode> prop to the
+              component.
             </>
             <>
-              using the NewsKit React hook{' '}
-              <InlineCode>useInstrumentation</InlineCode>. This will return an
+              Use the NewsKit React hook{' '}
+              <InlineCode>useInstrumentation</InlineCode>. This returns an
               object containing the <InlineCode>fireEvent</InlineCode> function.
             </>
           </UnorderedList>
           <P overrides={contentOverrides}>
-            You can then call this function with your custom instrumentation
-            event as necessary, so long as it meets event requirements. Event
-            objects must contain an event <InlineCode>originator</InlineCode>{' '}
-            (the name of the component firing the event) and an event
+            You can call this function with your custom instrumentation event as
+            necessary, so long as it meets event requirements.
+            <br />
+            <br />
+            Event objects must contain an event{' '}
+            <InlineCode>originator</InlineCode> (the name of the component
+            firing the event) and an event
             <InlineCode>trigger</InlineCode> from the{' '}
             <InlineCode>EventTrigger</InlineCode> enum listed below (this can be
             used as a JS object or the direct string values in non-TS projects).
+            <br />
+            <br />
             Events can also contain a <InlineCode>context</InlineCode> object,
             which can be any JSON-serializable structure.
           </P>
@@ -369,15 +400,16 @@ export const MySpecialCustomButton: React.FC<
               It is possible to build up and extend the context of an event by
               nesting instances of the{' '}
               <InlineCode>InstrumentationProvider</InlineCode>. Each provider
-              can take a context object which will be shallow merged onto the
+              can take a context object which will be shallow-merged onto the
               parent when an event is fired.
               <br />
               <br />
               This can be useful to build up event information that is specific
-              to a particular component instance, without that component needing
-              to know anything outside its own scope. For example, a button can
-              fire a click event, but the layers of context can provide the
-              information on what the button is for and where it is on the page.
+              to a particular component instance - without that component
+              needing to know anything outside its own scope. For example, a
+              button can fire a click event, but the layers of context can
+              provide the information on what the button is for and where it is
+              on the page.
             </>
           }
         >
@@ -450,11 +482,13 @@ const App = () => (
               In this example, we have a root{' '}
               <InlineCode>NewsKitProvider</InlineCode> providing the page URL.
               Inside the <InlineCode>Rail</InlineCode> component, we have{' '}
-              <InlineCode>InstrumentationProvider</InlineCode>; this provides
+              <InlineCode>InstrumentationProvider</InlineCode> - this provides
               any child events with rail specifics, like the rail name. The{' '}
-              <InlineCode>RailItem</InlineCode> then contains a button that
-              fires a click event. The resulting click event would look like
-              this:
+              <InlineCode>RailItem</InlineCode> contains a button that fires a
+              click event.
+              <br />
+              <br />
+              This is the resulting click event:
             </>
           }
         >
@@ -476,12 +510,13 @@ const App = () => (
               It is important to remember that in the example above, the{' '}
               <InlineCode>fireEvent</InlineCode> function is scoped to the
               context of the parent provider (the one which wraps the{' '}
-              <InlineCode>RailItem</InlineCode>). This means if we wanted to add
-              more context to the event inside the{' '}
-              <InlineCode>RailItem</InlineCode>, in the example above, doing the
-              following would NOT work as expected. The{' '}
-              <InlineCode>railItemId</InlineCode> we are adding to the context
-              would NOT appear on the event context.
+              <InlineCode>RailItem</InlineCode>).
+              <br />
+              <br />
+              This means if we wanted to add more context to the event inside
+              the <InlineCode>RailItem</InlineCode>, doing the following would
+              NOT work as expected. The <InlineCode>railItemId</InlineCode> we
+              are adding to the context would NOT appear in the event context.
             </>
           }
         >
@@ -538,11 +573,14 @@ return (
         <ContentSecondary
           description={
             <>
-              Instead, we can add context to the event directly (or we must put
+              Instead, you can add context to the event directly (or we must put
               the button into a separate component and get the{' '}
               <InlineCode>fireEvent</InlineCode>
-              function at that scope level). Passing context information via the
-              fireEvent function is the simpler of the two options:
+              function at that scope level).
+              <br />
+              <br />
+              Passing context information via the{' '}
+              <InlineCode>fireEvent</InlineCode> function is the simpler option:
             </>
           }
           showSeparator

--- a/site/pages/getting-started/design/design-overview.tsx
+++ b/site/pages/getting-started/design/design-overview.tsx
@@ -27,7 +27,7 @@ const PRINCIPLE_CARDS = [
     media: () => (
       <Illustration path="guides/design-overview/design-made-easy" />
     ),
-    title: 'Ease of use',
+    title: 'Easy',
     description:
       'NewsKit makes it simple to design beautiful, responsive, accessible experiences that align to the components in code - so you can concentrate on your users.',
     stylePrefix: 'featureCard',
@@ -37,7 +37,7 @@ const PRINCIPLE_CARDS = [
     media: () => (
       <Illustration path="guides/design-overview/complete-flexibility" />
     ),
-    title: 'Complete flexibility',
+    title: 'Flexible',
     description: (
       <>
         NewsKit is fully customisable, with a powerful{' '}

--- a/site/pages/getting-started/overview.tsx
+++ b/site/pages/getting-started/overview.tsx
@@ -40,14 +40,14 @@ const Overview = (layoutProps: LayoutProps) => (
   <Layout {...layoutProps} newPage>
     <HeadNextSeo
       title="Guides overview"
-      description="Use the guides below to help you get the most out of using NewsKit."
+      description="Get the most out of NewsKit with easy-to-follow guides."
       image={{
         url: 'social/guides.png',
         alt: 'Guides overview',
       }}
     />
     <HeaderIndex title="Guides" media={HeaderImage}>
-      Use the guides below to help you get the most out of using NewsKit.
+      Get the most out of NewsKit with easy-to-follow guides.
     </HeaderIndex>
     <Grid>
       <ComponentPageCell>

--- a/site/routes.ts
+++ b/site/routes.ts
@@ -49,7 +49,7 @@ export const routes = [
             page: true,
             id: '/getting-started/design/design-overview',
             description:
-              'Everything you need to know about using NewsKit to design digital products.',
+              'Everything you need to know about designing digital products with NewsKit.',
             illustration: 'guides/design-overview/hero',
             cardTitle: 'Design Overview',
           },
@@ -64,18 +64,18 @@ export const routes = [
             page: true,
             id: '/getting-started/code/engineering-overview',
             description:
-              'Everything you need to know about using NewsKit’s library of React web components.',
+              'Everything you need to know about NewsKit’s library of React web components.',
             illustration: 'guides/engineering-overview/hero',
-            cardTitle: 'Engineering Overview',
+            cardTitle: 'Engineering overview',
           },
           {
             title: 'Quickstart',
             page: true,
             id: '/getting-started/code/engineering-quickstart',
             description:
-              'Guides on how to get started building a web application with NewsKit.',
+              'Guides to start building web applications with NewsKit.',
             illustration: 'guides/engineering-quickstart/hero',
-            cardTitle: 'Engineering Quickstart Guide',
+            cardTitle: 'Engineering quickstart',
           },
           {
             title: 'Grid Layout step-by-step',


### PR DESCRIPTION
PPDSC-2545

**What**

1. Copy changes
2. Updated copy in guides pages

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [x] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
