### PR TITLE
fix(PPDSC-2554): link does not break to multiple lines

### DIFF
--- a/site/pages/components/link.tsx
+++ b/site/pages/components/link.tsx
@@ -104,6 +104,25 @@ const LinkComponent = (layoutProps: LayoutProps) => (
               },
             ],
           },
+          {
+            name: 'textOnly',
+            propName: 'textOnly',
+            options: [
+              {
+                label: 'Unset',
+                value: undefined,
+                isdefault: true,
+              },
+              {
+                label: 'true',
+                value: true,
+              },
+              {
+                label: 'false',
+                value: false,
+              },
+            ],
+          },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ] as any,
       },
@@ -402,6 +421,20 @@ const LinkComponent = (layoutProps: LayoutProps) => (
                 </>
               ),
             },
+            {
+              name: 'textOnly',
+              type: 'boolean',
+              description: (
+                <>
+                  Allows the link to break into multiple lines.
+                  <br />
+                  <br />
+                  Note - when this is true custom icons can&apos;t be passed as
+                  children to the LinkInline component. Custom icons can still
+                  be added before or after the LinkInline component.
+                </>
+              ),
+            },
           ],
           overridesRows: [
             {
@@ -536,6 +569,20 @@ const LinkComponent = (layoutProps: LayoutProps) => (
                   if the passed href is external or internal to the website
                   where the link is used. If the href is external, an icon
                   indicating this will be rendered after (trailing) the label.
+                </>
+              ),
+            },
+            {
+              name: 'textOnly',
+              type: 'boolean',
+              description: (
+                <>
+                  Allows the link to break into multiple lines.
+                  <br />
+                  <br />
+                  Note - when this is true custom icons can&apos;t be passed as
+                  children to the LinkStandalone component. Custom icons can
+                  still be added before or after the LinkInline component.
                 </>
               ),
             },

--- a/src/banner/__tests__/__snapshots__/banner.test.tsx.snap
+++ b/src/banner/__tests__/__snapshots__/banner.test.tsx.snap
@@ -753,7 +753,6 @@ exports[`Banner renders with content as string and link 1`] = `
 }
 
 .emotion-9 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1128,7 +1127,6 @@ exports[`Banner renders with content as string and link 1`] = `
 }
 
 .emotion-9 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/src/byline/__tests__/__snapshots__/byline.test.tsx.snap
+++ b/src/byline/__tests__/__snapshots__/byline.test.tsx.snap
@@ -76,7 +76,6 @@ exports[`Byline renders correctly multiple authors with link only 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -463,7 +462,6 @@ exports[`Byline renders correctly with authors and links 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -776,7 +774,6 @@ exports[`Byline renders correctly with authors, location, titles and links 1`] =
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1057,7 +1054,6 @@ exports[`Byline renders correctly with logical props overrides 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1555,7 +1551,6 @@ exports[`Byline renders correctly with overrides 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #d82059;
 }
 

--- a/src/consent/__tests__/__snapshots__/consent-settings-link.test.tsx.snap
+++ b/src/consent/__tests__/__snapshots__/consent-settings-link.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`ConsentSettingsLink with children renders link with custom text 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -128,7 +127,6 @@ exports[`ConsentSettingsLink with children renders link with custom text 1`] = `
 exports[`ConsentSettingsLink with link props renders link with styles 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -253,7 +251,6 @@ exports[`ConsentSettingsLink with link props renders link with styles 1`] = `
 exports[`ConsentSettingsLink with no children renders link with default text 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/link/__tests__/__snapshots__/link.test.tsx.snap
+++ b/src/link/__tests__/__snapshots__/link.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Link does not render the external icon even if the href is external 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -129,7 +128,6 @@ exports[`Link does not render the external icon even if the href is external 1`]
 exports[`Link does not render the external icon if the href is internal 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -255,7 +253,6 @@ exports[`Link does not render the external icon if the href is internal 1`] = `
 exports[`Link renders as expected in default state 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -381,7 +378,6 @@ exports[`Link renders as expected in default state 1`] = `
 exports[`Link renders the external icon even if the href is internal 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -575,7 +571,6 @@ exports[`Link renders the external icon even if the href is internal 1`] = `
 exports[`Link renders the external icon if the href is external 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -701,7 +696,6 @@ exports[`Link renders the external icon if the href is external 1`] = `
 exports[`Link renders with logical props overrides 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -829,7 +823,6 @@ exports[`Link renders with logical props overrides 1`] = `
 exports[`Link renders with overrides 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #D60000;
 }
 
@@ -920,7 +913,6 @@ exports[`Link renders with overrides 1`] = `
 exports[`LinkStandalone renders as expected in default state 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1044,7 +1036,6 @@ exports[`LinkStandalone renders as expected in default state 1`] = `
 exports[`LinkStandalone renders with logical props overrides 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/link/__tests__/link.stories.tsx
+++ b/src/link/__tests__/link.stories.tsx
@@ -10,6 +10,7 @@ import {
 import {IconFilledEmail} from '../../icons';
 import {ThemeProvider, CreateThemeArgs} from '../../theme';
 import {createCustomThemeWithBaseThemeSwitch} from '../../test/theme-select-object';
+import {TextBlock} from '../../text-block';
 
 const linkCustomThemeObject: CreateThemeArgs = {
   name: 'my-custom-link-theme',
@@ -163,7 +164,6 @@ export const StoryLink = () => (
     <StorybookHeading>Link inline</StorybookHeading>
     <LinkInline href="/">Inline link</LinkInline>
     <br />
-    <br />
     <LinkInline
       href="/"
       overrides={{
@@ -174,13 +174,11 @@ export const StoryLink = () => (
       Inline link with style and type overrides
     </LinkInline>
     <br />
-    <br />
     <LinkInline href="/">
       <IconFilledEmail overrides={{size: 'iconSize010'}} />
       Inline link with leading and trailing icons
       <IconFilledEmail overrides={{size: 'iconSize010'}} />
     </LinkInline>
-    <br />
     <br />
     <LinkInline
       href="/"
@@ -193,9 +191,7 @@ export const StoryLink = () => (
       <IconFilledEmail overrides={{size: 'iconSize010'}} />
     </LinkInline>
     <br />
-    <br />
     <LinkInline href="mailto:###">Inline mail link</LinkInline>
-    <br />
     <br />
     <LinkInline href="tel:###">Inline telephone link</LinkInline>
 
@@ -207,7 +203,6 @@ export const StoryLink = () => (
     >
       External link with external icon
     </LinkInline>
-    <br />
     <br />
     <LinkInline
       href="http://newskit.staging-news.co.uk/"
@@ -221,7 +216,6 @@ export const StoryLink = () => (
       External link with custom size for external icon
     </LinkInline>
     <br />
-    <br />
     <LinkInline
       href="http://newskit.staging-news.co.uk/"
       external={false}
@@ -234,11 +228,9 @@ export const StoryLink = () => (
     <StorybookHeading>Link standalone</StorybookHeading>
     <LinkStandalone href="/">Standalone link</LinkStandalone>
     <br />
-    <br />
     <LinkStandalone href="https://google.com">
       Standalone link external
     </LinkStandalone>
-    <br />
     <br />
     <LinkStandalone
       href="https://google.com"
@@ -249,6 +241,25 @@ export const StoryLink = () => (
     >
       Link Standalone external with type and style Preset overrides
     </LinkStandalone>
+
+    <StorybookHeading>Link with `textOnly`</StorybookHeading>
+    <TextBlock>
+      This is a long description with this and this and this and this and this
+      and{' '}
+      <LinkInline textOnly href="/">
+        long textOnly inline link inside{' '}
+      </LinkInline>{' '}
+      and this and that.
+    </TextBlock>
+
+    <br />
+    <TextBlock>
+      This is a great article about this and this and this and that and this and{' '}
+      <LinkInline textOnly href="http://newskit.staging-news.co.uk/">
+        external textOnly link with external icon
+      </LinkInline>{' '}
+      this and this and this and that.
+    </TextBlock>
   </Container>
 );
 StoryLink.storyName = 'link';

--- a/src/link/internal-link.tsx
+++ b/src/link/internal-link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {styled, getStylePreset} from '../utils/style';
 import {EventTrigger, useInstrumentation} from '../instrumentation';
 import {InternalLinkProps} from './types';
@@ -13,7 +13,6 @@ import {logicalProps} from '../utils/logical-properties';
 import {getTransitionPreset} from '../utils/style/transition-preset';
 
 const StyledLink = styled.a<InternalLinkProps>`
-  display: inline-block;
   ${getTransitionPreset(`link`, '')};
   ${getStylePreset('link', '')}
   ${logicalProps('link')}
@@ -32,6 +31,7 @@ export const InternalLink = React.forwardRef<
     noCrop,
     href,
     external,
+    textOnly,
     children,
     overrides,
     eventContext,
@@ -64,6 +64,17 @@ export const InternalLink = React.forwardRef<
   const willRenderExternalIcon =
     external === undefined ? hasMounted && isLinkExternal(href) : external;
 
+  const renderExternalIcon = useMemo(
+    () =>
+      willRenderExternalIcon && (
+        <IconFilledLaunch
+          title="External link"
+          overrides={{size: externalIconSize}}
+        />
+      ),
+    [externalIconSize, willRenderExternalIcon],
+  );
+
   return (
     <StyledLink
       ref={ref}
@@ -82,36 +93,38 @@ export const InternalLink = React.forwardRef<
         }
       }}
     >
-      <Stack
-        flow="horizontal-center"
-        spaceInline={
-          willRenderExternalIcon || React.Children.count(children) !== 1
-            ? spaceInBetween
-            : null
-        }
-        as="span"
-      >
-        {React.Children.map(children, child =>
-          typeof child === 'string' ? (
-            <StyledTextBlock
-              noCrop={noCrop}
-              as="span"
-              typographyPreset={typographyPreset}
-            >
-              {child}
-            </StyledTextBlock>
-          ) : (
-            child
-          ),
-        )}
+      {textOnly ? (
+        <>
+          {children}
+          {renderExternalIcon}
+        </>
+      ) : (
+        <Stack
+          flow="horizontal-center"
+          spaceInline={
+            willRenderExternalIcon || React.Children.count(children) !== 1
+              ? spaceInBetween
+              : null
+          }
+          as="span"
+        >
+          {React.Children.map(children, child =>
+            typeof child === 'string' ? (
+              <StyledTextBlock
+                noCrop={noCrop}
+                as="span"
+                typographyPreset={typographyPreset}
+              >
+                {child}
+              </StyledTextBlock>
+            ) : (
+              child
+            ),
+          )}
 
-        {willRenderExternalIcon && (
-          <IconFilledLaunch
-            title="External link"
-            overrides={{size: externalIconSize}}
-          />
-        )}
-      </Stack>
+          {renderExternalIcon}
+        </Stack>
+      )}
     </StyledLink>
   );
 });

--- a/src/link/types.ts
+++ b/src/link/types.ts
@@ -24,6 +24,7 @@ export interface InternalLinkProps extends BaseLinkProps {
   external?: boolean;
   overrides?: LinkOverrides;
   noCrop?: boolean;
+  textOnly?: boolean;
 }
 
 export interface LinkProps extends Omit<InternalLinkProps, 'noCrop'> {}

--- a/src/share-bar/__tests__/__snapshots__/share-bar.test.tsx.snap
+++ b/src/share-bar/__tests__/__snapshots__/share-bar.test.tsx.snap
@@ -225,7 +225,6 @@ exports[`ShareBar renders horizontally with icons as links and label 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -892,7 +891,6 @@ exports[`ShareBar renders whatever components are passed to it 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1302,7 +1300,6 @@ exports[`ShareBar renders with custom label stylePreset 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1707,7 +1704,6 @@ exports[`ShareBar renders with custom stack spacing 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -2112,7 +2108,6 @@ exports[`ShareBar renders with horizontally with overrides for label spacing 1`]
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -2571,7 +2566,6 @@ exports[`ShareBar renders with overrides for item spacing 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -2976,7 +2970,6 @@ exports[`ShareBar renders with overrides for label typographyPreset 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -3381,7 +3374,6 @@ exports[`ShareBar renders with vertically with overrides for label spacing 1`] =
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/src/title-bar/__tests__/__snapshots__/title-bar.test.tsx.snap
+++ b/src/title-bar/__tests__/__snapshots__/title-bar.test.tsx.snap
@@ -764,7 +764,6 @@ exports[`TitleBar Should display correctly with action item as: Link 1`] = `
 }
 
 .emotion-5 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/src/toast/__tests__/__snapshots__/toast.test.tsx.snap
+++ b/src/toast/__tests__/__snapshots__/toast.test.tsx.snap
@@ -1578,7 +1578,6 @@ exports[`Toast Component renders with content as string and link 1`] = `
 }
 
 .emotion-4 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/src/unordered-list/__tests__/__snapshots__/unordered-list.test.tsx.snap
+++ b/src/unordered-list/__tests__/__snapshots__/unordered-list.test.tsx.snap
@@ -151,7 +151,6 @@ exports[`UnorderedList renders different types of children 1`] = `
 }
 
 .emotion-19 {
-  display: inline-block;
   color: #3358CC;
   -webkit-text-decoration: underline;
   text-decoration: underline;


### PR DESCRIPTION
PPDSC-2554

**What**

1. Background - why this is needed
- Dow Jones have a requirement to break links on multiple lines if they are at the end of the container width.
2. What did you do
- added `textOnly` props which when passed, we remove the `<Stack>` from the `<Link>` component and allow it to render as inline element which will wrap on multiple lines. 
- when `textOnly` is used, the end users would not be able to pass icons inside the `<Link> `children, they can achieve similar result by adding custom icons before or after the `<Link>` tag.
3. What does the reviewers should expect
- updated storybook examples
- new `textOnly` prop
- updated docs 
- link using `textOnly` should wrap on multiple lines.

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->
**Screenshot**
<img width="689" alt="image" src="https://user-images.githubusercontent.com/7677924/203059972-216d1b46-a51a-4211-b8d1-7044a9241247.png">


<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [x] Updated relevant documentation

**I have tested manually:**
- [x] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [x] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
