### PR TITLE
docs(PPDSC-2650): react error on components overview

### DIFF
--- a/site/components/media-list/media-list.tsx
+++ b/site/components/media-list/media-list.tsx
@@ -64,12 +64,13 @@ export const MediaList: React.FC<MediaListProps> = ({
         return (
           // eslint-disable-next-line react/no-array-index-key
           <Cell {...cellColumnList} key={`index-${index}`}>
-            {cardProps.href && (
+            {cardProps.href ? (
               <NextLink legacyBehavior href={cardProps.href} passHref>
                 {styledCardComponentWithProps}
               </NextLink>
+            ) : (
+              styledCardComponentWithProps
             )}
-            {!cardProps.href && styledCardComponentWithProps}
           </Cell>
         );
       }),

--- a/site/pages/components/overview.tsx
+++ b/site/pages/components/overview.tsx
@@ -8,7 +8,6 @@ import {
   StructuredListCell,
   StructuredListItem,
   TextBlock,
-  useBreakpointKey,
 } from 'newskit';
 import {ComponentPageCell} from '../../components/layout-cells';
 import {Separator} from '../../components/separator';
@@ -40,161 +39,145 @@ const deprecated = componentsSubNav?.find(e => e.id === '/deprecated');
 
 const pageDescription = `Components are key building blocks of the NewsKit design system.`;
 
-const OverviewComponent = (layoutProps: LayoutProps) => {
-  const breakpoint = useBreakpointKey();
-
-  return (
-    <Layout {...layoutProps} newPage>
-      <HeadNextSeo
-        title="Components overview"
-        description={pageDescription}
-        image={{
-          url: 'social/components.png',
-          alt: 'Components overview',
-        }}
-      />
-      <HeaderIndex title="Components" media={HeaderImage}>
-        {pageDescription}
-      </HeaderIndex>
-      <Grid lgMargin="sizing000" xsRowGutter="sizing000">
-        {componentCategories.map(
-          ({title, description, subNav}: any, i: number) => (
-            <React.Fragment key={title}>
-              {i === 0 ? (
-                <Cell xs={12}>
-                  <SectionIntroduction
-                    title={title}
-                    cellProps={{lg: 8, mdOffset: i === 0 ? 1 : undefined}}
-                    subHeadingSpaceStack="space000"
+const OverviewComponent = (layoutProps: LayoutProps) => (
+  <Layout {...layoutProps} newPage>
+    <HeadNextSeo
+      title="Components overview"
+      description={pageDescription}
+      image={{
+        url: 'social/components.png',
+        alt: 'Components overview',
+      }}
+    />
+    <HeaderIndex title="Components" media={HeaderImage}>
+      {pageDescription}
+    </HeaderIndex>
+    <Grid lgMargin="sizing000" xsRowGutter="sizing000">
+      {componentCategories.map(
+        ({title, description, subNav}: any, i: number) => (
+          <React.Fragment key={title}>
+            {i === 0 ? (
+              <Cell xs={12}>
+                <SectionIntroduction
+                  title={title}
+                  cellProps={{lg: 8, mdOffset: i === 0 ? 1 : undefined}}
+                  subHeadingSpaceStack="space000"
+                >
+                  {description}
+                </SectionIntroduction>
+              </Cell>
+            ) : (
+              <Cell xs={12}>
+                <SectionIntroduction
+                  subHeadingSpaceStack="space080"
+                  title={title}
+                  cellProps={{lg: 8}}
+                >
+                  {description}
+                </SectionIntroduction>
+              </Cell>
+            )}
+            <ComponentPageCell>
+              <MediaList
+                cards={subNav.map((comp: any) => ({
+                  media: comp.illustration
+                    ? getIllustrationComponent(comp.illustration)
+                    : {
+                        src: comp.media,
+                        alt: '',
+                      },
+                  title: comp.title,
+                  href: comp.id,
+                  description: comp.description,
+                }))}
+                gridProps={{xsRowGutter: 'space050'}}
+              />
+            </ComponentPageCell>
+            <ComponentPageCell>
+              <Separator />
+            </ComponentPageCell>
+          </React.Fragment>
+        ),
+      )}
+      <Cell xs={12}>
+        <SectionIntroduction
+          subHeadingSpaceStack="space080"
+          title={utilities.title}
+          cellProps={{lg: 8}}
+        >
+          {utilities.description}
+        </SectionIntroduction>
+        <ComponentPageCell>
+          <Block stylePreset="componentsUtilitiesStructuredList">
+            <StructuredList divider>
+              {utilities?.subNav?.map(
+                (util: {
+                  title: string;
+                  page: boolean;
+                  id: string;
+                  description: string;
+                }) => (
+                  <StructuredListItem
+                    key={util.id}
+                    href={util.id}
+                    ariaLabel={util.title}
                   >
-                    {description}
-                  </SectionIntroduction>
-                </Cell>
-              ) : (
-                <Cell xs={12}>
-                  <SectionIntroduction
-                    subHeadingSpaceStack="space080"
-                    title={title}
-                    cellProps={{lg: 8}}
-                  >
-                    {description}
-                  </SectionIntroduction>
-                </Cell>
+                    <StructuredListCell>
+                      <TextBlock
+                        stylePreset="inkContrast"
+                        typographyPreset="utilityHeading010"
+                      >
+                        {util.title}
+                      </TextBlock>
+                      <TextBlock
+                        marginBlockStart="space030"
+                        stylePreset="inkContrast"
+                        typographyPreset="utilityBody020"
+                      >
+                        {util.description}
+                      </TextBlock>
+                    </StructuredListCell>
+                  </StructuredListItem>
+                ),
               )}
-              <ComponentPageCell>
-                <MediaList
-                  cards={subNav.map((comp: any) => ({
-                    media: comp.illustration
-                      ? getIllustrationComponent(comp.illustration)
-                      : {
-                          src: comp.media,
-                          alt: '',
-                        },
-                    title: comp.title,
-                    href: comp.id,
-                    description: comp.description,
-                  }))}
-                  gridProps={{xsRowGutter: 'space050'}}
-                />
-              </ComponentPageCell>
-              <ComponentPageCell>
-                <Separator />
-              </ComponentPageCell>
-            </React.Fragment>
-          ),
-        )}
+            </StructuredList>
+          </Block>
+        </ComponentPageCell>
+      </Cell>
+      <ComponentPageCell>
+        <Separator />
+      </ComponentPageCell>
+      <React.Fragment key={deprecated.title}>
         <Cell xs={12}>
           <SectionIntroduction
             subHeadingSpaceStack="space080"
-            title={utilities.title}
+            title={deprecated.title}
             cellProps={{lg: 8}}
           >
-            {utilities.description}
+            {deprecated.description}
           </SectionIntroduction>
-          <ComponentPageCell>
-            <Block stylePreset="componentsUtilitiesStructuredList">
-              <StructuredList divider>
-                {utilities?.subNav?.map(
-                  (util: {
-                    title: string;
-                    page: boolean;
-                    id: string;
-                    description: string;
-                  }) => (
-                    <StructuredListItem
-                      key={util.id}
-                      href={util.id}
-                      ariaLabel={util.title}
-                    >
-                      <StructuredListCell>
-                        <TextBlock
-                          stylePreset="inkContrast"
-                          typographyPreset="utilityHeading010"
-                        >
-                          {util.title}
-                        </TextBlock>
-                        {breakpoint !== 'xs' && breakpoint !== 'sm' && (
-                          <TextBlock
-                            marginBlockStart="space030"
-                            stylePreset="inkContrast"
-                            typographyPreset="utilityBody020"
-                          >
-                            {util.description}
-                          </TextBlock>
-                        )}
-                      </StructuredListCell>
-                      {(breakpoint === 'xs' || breakpoint === 'sm') && (
-                        <StructuredListCell>
-                          <TextBlock
-                            stylePreset="inkContrast"
-                            typographyPreset="utilityBody020"
-                          >
-                            {util.description}
-                          </TextBlock>
-                        </StructuredListCell>
-                      )}
-                    </StructuredListItem>
-                  ),
-                )}
-              </StructuredList>
-            </Block>
-          </ComponentPageCell>
         </Cell>
         <ComponentPageCell>
-          <Separator />
+          <MediaList
+            cards={deprecated?.subNav?.map((comp: any) => ({
+              media: comp.illustration
+                ? getIllustrationComponent(comp.illustration)
+                : {
+                    src: comp.media,
+                    alt: '',
+                  },
+              title: comp.title,
+              href: comp.id,
+              description: comp.description,
+            }))}
+            gridProps={{xsRowGutter: 'space050'}}
+          />
         </ComponentPageCell>
-        <React.Fragment key={deprecated.title}>
-          <Cell xs={12}>
-            <SectionIntroduction
-              subHeadingSpaceStack="space080"
-              title={deprecated.title}
-              cellProps={{lg: 8}}
-            >
-              {deprecated.description}
-            </SectionIntroduction>
-          </Cell>
-          <ComponentPageCell>
-            <MediaList
-              cards={deprecated?.subNav?.map((comp: any) => ({
-                media: comp.illustration
-                  ? getIllustrationComponent(comp.illustration)
-                  : {
-                      src: comp.media,
-                      alt: '',
-                    },
-                title: comp.title,
-                href: comp.id,
-                description: comp.description,
-              }))}
-              gridProps={{xsRowGutter: 'space050'}}
-            />
-          </ComponentPageCell>
-        </React.Fragment>
-      </Grid>
+      </React.Fragment>
+    </Grid>
 
-      <Block spaceStack="space070" />
-    </Layout>
-  );
-};
+    <Block spaceStack="space070" />
+  </Layout>
+);
 
 export default OverviewComponent;


### PR DESCRIPTION
PPDSC-2650

- Checked with Mike to remove the extra cell on smaller breakpoints. 


<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->


[PPDSC-2650]: https://nidigitalsolutions.jira.com/browse/PPDSC-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ