### PR TITLE
spike(PPDSC-2577): card composable

### DIFF
--- a/src/grid-layout/__tests__/stories/grid-card.tsx
+++ b/src/grid-layout/__tests__/stories/grid-card.tsx
@@ -209,7 +209,7 @@ const Card = ({
   href,
   ...props
 }: GridLayoutProps & {href?: string}) => {
-  //const hasTouchLinkInChildren = href && hasTouchLink(children, href);
+  // const hasTouchLinkInChildren = href && hasTouchLink(children, href);
 
   return (
     // @ts-ignore
@@ -228,16 +228,16 @@ const Card = ({
   );
 };
 
-const CardMedia = ({src}) => (
-  <img src={src} alt="" style={{maxWidth: '100%'}} />
+const CardMedia = ({src, style}) => (
+  <img src={src} alt="" style={{maxWidth: '100%', ...style}} />
 );
 
 const CardContent = (props: GridLayoutProps) => <GridLayout {...props} />;
 
 // Card Actions has larger z-index than Cover link so goes over it
 const StyledCardActions = styled(GridLayout)`
-  z-index: 2;
   position: relative;
+  z-index: 2;
 `;
 
 const CardActions = (props: GridLayoutProps) => (
@@ -246,18 +246,18 @@ const CardActions = (props: GridLayoutProps) => (
 
 const StyledCardTouchArea = styled(GridLayout)`
   ${props =>
-    props.full &&
-    `&:before {
-    content: '';
-    z-index: 1;
-    position: absolute;
-    inset: 0;
-  }`}
+    props.expand &&
+    `
+    &:before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+    }
+    `}
 `;
 
-const CardTouchArea = (
-  props: GridLayoutProps & {href: string; full: boolean},
-) => (
+const CardLink = (props: GridLayoutProps & {href: string; expand: boolean}) => (
   // @ts-ignore
   <StyledCardTouchArea as="a" {...props} />
 );
@@ -269,10 +269,17 @@ const StyledCardCoverLink = styled(GridLayoutItem)`
   inset: 0;
 `;
 
-const CardCoverLink = (props: GridLayoutItemProps & {href: string}) => (
-  // @ts-ignore
-  <StyledCardCoverLink as="a" {...props} />
-);
+// const CardCoverLink = (props: GridLayoutItemProps & {href: string}) => (
+//   // @ts-ignore
+//   <StyledCardCoverLink as="a" {...props} />
+// );
+
+/*
+
+Maybe having interactive prop on every Card* element?
+
+
+*/
 
 const cardHref = '/card-link';
 
@@ -280,16 +287,18 @@ export const CardComposableExample = () => (
   <Card
     overrides={{maxWidth: '320px', stylePreset: 'cardComposable'}}
     rowGap="space040"
+    // columns="auto 1fr"
     // href={cardHref}
   >
-    <CardMedia src="/placeholder-3x2.png" />
-
     <CardContent rowGap="space040">
-      <CardTouchArea href={cardHref} full>
+      <CardLink href={cardHref} expand>
         <Headline kickerText="KICKER">Title of the card</Headline>
-      </CardTouchArea>
+      </CardLink>
+
       <Paragraph>Some kind of intro</Paragraph>
     </CardContent>
+
+    <CardMedia src="/placeholder-3x2.png" style={{order: '-1'}} />
 
     {/* contains actions like links or buttons, they are placed above CardCoverLink when present */}
     <CardActions

--- a/src/grid-layout/__tests__/stories/grid-card.tsx
+++ b/src/grid-layout/__tests__/stories/grid-card.tsx
@@ -272,43 +272,47 @@ const StyledCardLink = styled(GridLayout)`
     `}
 `;
 
-const CardLink = (props: GridLayoutProps & {href: string; expand: boolean}) => (
-  <StyledCardLink as="a" {...props} />
-);
+const CardLink = (
+  props: GridLayoutProps & {href: string; expand?: boolean},
+) => <StyledCardLink as="a" {...props} />;
 
 const cardHref = '/card-link';
 
 export const CardComposableExample = () => (
   <Card
     overrides={{
-      maxWidth: {xl: '600px', md: '320px'},
+      maxWidth: {xl: '600px', md: '420px'},
       stylePreset: 'cardComposable',
     }}
     rowGap="space040"
-    // columns={{xs: '200px 1fr', md: '1fr'}}
-    // areas={{
-    //   xs: `
-    //     media content
-    //     media actions
-    //   `,
-    //   md: `
-    //     media
-    //     content
-    //     actions
-    //   `,
-    // }}
+    columns={{xs: '200px 1fr', md: '1fr'}}
+    areas={{
+      xs: `
+        media content
+        media actions
+      `,
+      md: `
+        media
+        content
+        actions
+      `,
+    }}
   >
-    <CardMedia src="/placeholder-3x2.png" />
-
-    <CardContent rowGap="space040">
-      <CardLink href={cardHref}>
+    <CardContent
+      rowGap="space040"
+      overrides={{paddingInline: 'space040', paddingBlockStart: 'space040'}}
+    >
+      <CardLink href={cardHref} expand>
         <Headline kickerText="KICKER">Title of the card</Headline>
       </CardLink>
-
       <Paragraph>Some kind of intro</Paragraph>
     </CardContent>
 
-    <CardActions>
+    <CardMedia src="/placeholder-3x2.png" />
+
+    <CardActions
+      overrides={{paddingInline: 'space040', paddingBlockEnd: 'space040'}}
+    >
       <Tag href="/news">News</Tag>
     </CardActions>
   </Card>

--- a/src/grid-layout/__tests__/stories/grid-card.tsx
+++ b/src/grid-layout/__tests__/stories/grid-card.tsx
@@ -5,9 +5,10 @@ import {Block} from '../../../block';
 import {styled} from '../../../utils/style';
 import {Button} from '../../../button';
 import {Image} from '../../../image';
-import {Flag, getMediaQueryFromTheme} from '../../..';
+import {Flag, getMediaQueryFromTheme, Paragraph, Tag} from '../../..';
 import {IconFilledEmail} from '../../../icons';
-import {GridLayout} from '../../grid-layout';
+import {GridLayout, GridLayoutItem} from '../../grid-layout';
+import {GridLayoutItemProps, GridLayoutProps} from '../../types';
 
 const StyledAdvancedCard = styled(GridLayout)`
   border: 1px solid gray;
@@ -174,3 +175,63 @@ export const GridTeaser = ({
     </StyledAdvancedCard>
   );
 };
+
+const StyledCard = styled(GridLayout)`
+  position: relative;
+`;
+
+const Card = (props: GridLayoutProps) => <StyledCard {...props} />;
+
+const CardMedia = ({src}) => (
+  <img src={src} alt="" style={{maxWidth: '100%'}} />
+);
+
+const CardContent = (props: GridLayoutItemProps) => (
+  <GridLayoutItem {...props} />
+);
+
+const CardActions = (props: GridLayoutItemProps) => (
+  <GridLayoutItem {...props} />
+);
+
+const StyledGridActionArea = styled(GridLayoutItem)`
+  ${({full}) =>
+    full &&
+    `
+    &:before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+  
+  `}
+`;
+
+const CardActionArea = ({
+  href,
+  full = false,
+  row,
+  column,
+  ...props
+}: GridLayoutItemProps & {href?: string; full?: boolean}) => (
+  <StyledGridActionArea as="a" href={href} full={full} {...props} />
+);
+
+export const CardComposableExample = () => (
+  <>
+    <Card overrides={{maxWidth: '320px'}}>
+      <CardMedia src="/placeholder-3x2.png" />
+      <CardContent>
+        <CardActionArea href="/news">
+          <Headline kickerText="KICKER">Title of the card</Headline>
+        </CardActionArea>
+        <Paragraph>Some kind of intro</Paragraph>
+      </CardContent>
+      <CardActions>
+        <Tag href="/">News</Tag>
+        <Tag href="/">Music</Tag>
+        <Tag href="/">Festivals</Tag>
+      </CardActions>
+    </Card>
+  </>
+);

--- a/src/grid-layout/__tests__/stories/grid-layout.stories.tsx
+++ b/src/grid-layout/__tests__/stories/grid-layout.stories.tsx
@@ -3,7 +3,7 @@ import {styled} from '../../../utils';
 import {Block} from '../../../block';
 import {Divider} from '../../../divider';
 import {GridLayout, GridLayoutItem} from '../../grid-layout';
-import {GridCard, GridTeaser} from './grid-card';
+import {GridCard, GridTeaser, CardComposableExample} from './grid-card';
 import {GridBox} from './common';
 import {Grid, Cell} from '../../../grid';
 import {Label} from '../../..';
@@ -414,21 +414,9 @@ StoryWithLogicalPropsOverrides.storyName = 'with-logical-props';
 
 export const StoryCardWithGrid = () => (
   <>
+    <CardComposableExample />
+    <hr />
     <StorybookHeading>Card with grid</StorybookHeading>
-    <GridCard
-      href="#"
-      image="/placeholder-3x2.png"
-      title="title of the card describing the main content"
-      teaser="this is the teaser"
-    />
-    <Block spaceStack="100px" />
-    <Divider />
-    <Block spaceStack="100px" />
-    <GridTeaser
-      image="/placeholder-3x2.png"
-      title="title of the card describing the main content"
-      teaser="this is the teaser"
-    />
   </>
 );
 StoryCardWithGrid.storyName = 'card-with-grid';

--- a/src/theme/presets/style-presets.ts
+++ b/src/theme/presets/style-presets.ts
@@ -177,9 +177,12 @@ stylePresets.selectOptionItemIcon = {
 
 stylePresets.cardComposable = {
   base: {
-    backgroundColor: '#f4f4f4',
+    boxShadow: '{{shadows.shadow020}}',
+    borderRadius: '{{borders.borderRadiusRounded020}}',
+    backgroundColor: '{{colors.interface010}}',
   },
   hover: {
-    backgroundColor: '#ededed',
+    boxShadow: '{{shadows.shadow050}}',
+    backgroundColor: '{{colors.interface020}}',
   },
 };

--- a/src/theme/presets/style-presets.ts
+++ b/src/theme/presets/style-presets.ts
@@ -174,3 +174,12 @@ stylePresets.selectOptionItemIcon = {
     iconColor: '{{colors.interactiveInput040}}',
   },
 };
+
+stylePresets.cardComposable = {
+  base: {
+    backgroundColor: '#f4f4f4',
+  },
+  hover: {
+    backgroundColor: '#ededed',
+  },
+};


### PR DESCRIPTION
PPDSC-2577

**What**

1. Background - why this is needed
2. What did you do
3. What does the reviewers should expect

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
