### PR TITLE
feat(PPDSC-2696): set default padding block to 'space000' for breadCrumbItem

### DIFF
--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`BreadcrumbItem renders selected menu item with aria attributes 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -229,6 +230,7 @@ exports[`BreadcrumbItem renders with default props 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -404,6 +406,7 @@ exports[`BreadcrumbItem renders with overrides 1`] = `
   min-width: 10px;
   min-height: 11px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -541,6 +544,7 @@ exports[`Breadcrumbs renders in large size 1`] = `
   min-width: 120px;
   min-height: 64px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -837,6 +841,7 @@ exports[`Breadcrumbs renders in medium size 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1133,6 +1138,7 @@ exports[`Breadcrumbs renders in small size 1`] = `
   min-width: 64px;
   min-height: 32px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1429,6 +1435,7 @@ exports[`Breadcrumbs renders with default props 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1729,6 +1736,7 @@ exports[`Breadcrumbs renders with logical prop overrides 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2024,6 +2032,7 @@ exports[`Breadcrumbs renders with separator icon as overrides 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2319,6 +2328,7 @@ exports[`Breadcrumbs renders with separator overrides with TextBlock component 1
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2548,6 +2558,7 @@ exports[`Breadcrumbs renders with showTrailingSeparator 1`] = `
   min-width: 80px;
   min-height: 48px;
   padding-inline: 0;
+  padding-block: 0;
   box-sizing: border-box;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/breadcrumbs/__tests__/breadcrumbs.stories.tsx
+++ b/src/breadcrumbs/__tests__/breadcrumbs.stories.tsx
@@ -221,9 +221,17 @@ export const StoryLogicalProps = () => (
         overrides={{paddingBlock: 'space050'}}
         aria-label="padding-overrides"
       >
-        <BreadcrumbItem href={href}>Breadcrumb item</BreadcrumbItem>
-        <BreadcrumbItem href={href}>Breadcrumb item</BreadcrumbItem>
-        <BreadcrumbItem selected href={href}>
+        <BreadcrumbItem href={href} overrides={{paddingInline: 'space020'}}>
+          Breadcrumb item
+        </BreadcrumbItem>
+        <BreadcrumbItem href={href} overrides={{paddingInline: 'space020'}}>
+          Breadcrumb item
+        </BreadcrumbItem>
+        <BreadcrumbItem
+          selected
+          href={href}
+          overrides={{paddingInline: 'space020'}}
+        >
           Breadcrumb item
         </BreadcrumbItem>
       </Breadcrumbs>
@@ -233,9 +241,17 @@ export const StoryLogicalProps = () => (
         overrides={{marginBlock: 'space050'}}
         aria-label="margin-overrides"
       >
-        <BreadcrumbItem href={href}>Breadcrumb item</BreadcrumbItem>
-        <BreadcrumbItem href={href}>Breadcrumb item</BreadcrumbItem>
-        <BreadcrumbItem selected href={href}>
+        <BreadcrumbItem href={href} overrides={{marginInline: 'space020'}}>
+          Breadcrumb item
+        </BreadcrumbItem>
+        <BreadcrumbItem href={href} overrides={{marginInline: 'space020'}}>
+          Breadcrumb item
+        </BreadcrumbItem>
+        <BreadcrumbItem
+          selected
+          href={href}
+          overrides={{marginInline: 'space020'}}
+        >
           Breadcrumb item
         </BreadcrumbItem>
       </Breadcrumbs>

--- a/src/breadcrumbs/defaults.ts
+++ b/src/breadcrumbs/defaults.ts
@@ -4,16 +4,19 @@ export default {
       typographyPreset: 'utilityButton010',
       stylePreset: 'breadcrumbItem',
       paddingInline: 'space000',
+      paddingBlock: 'space000',
     },
     medium: {
       typographyPreset: 'utilityButton020',
       stylePreset: 'breadcrumbItem',
       paddingInline: 'space000',
+      paddingBlock: 'space000',
     },
     large: {
       typographyPreset: 'utilityButton030',
       stylePreset: 'breadcrumbItem',
       paddingInline: 'space000',
+      paddingBlock: 'space000',
     },
   },
   breadcrumbs: {

--- a/src/theme/__tests__/__snapshots__/theme.test.ts.snap
+++ b/src/theme/__tests__/__snapshots__/theme.test.ts.snap
@@ -1521,16 +1521,19 @@ Object {
   },
   "breadcrumbItem": Object {
     "large": Object {
+      "paddingBlock": "space000",
       "paddingInline": "space000",
       "stylePreset": "breadcrumbItem",
       "typographyPreset": "utilityButton030",
     },
     "medium": Object {
+      "paddingBlock": "space000",
       "paddingInline": "space000",
       "stylePreset": "breadcrumbItem",
       "typographyPreset": "utilityButton020",
     },
     "small": Object {
+      "paddingBlock": "space000",
       "paddingInline": "space000",
       "stylePreset": "breadcrumbItem",
       "typographyPreset": "utilityButton010",


### PR DESCRIPTION
PPDSC-2696

The breadcrumb item currently has padding top and bottom (inherited from the Button). 
This needs to be removed. There already is a paddingInline: 'space000' but need the same for paddingBlock

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [x] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [x] The screen reader reads and flows through the elements as expected.
- [x] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
