### PR TITLE
chore(PPDSC-2568): v1

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -12,3 +12,14 @@
         display: none !important
     }
 </style>
+
+<script>
+  window.onload = () => {
+    console.log('manager', window.location.search)
+    const urlParams = new URLSearchParams(window.location.search);
+    const embedded = urlParams.get('embedded') === 'true';
+    if (embedded) {
+      document.head.insertAdjacentHTML("beforeend", `<style>div.os-padding{display: none}</style>`)  
+    }
+  }
+</script>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {INITIAL_VIEWPORTS} from '@storybook/addon-viewport';
 import {withPerformance} from 'storybook-addon-performance';
 import {DocsContext} from '@storybook/addon-docs';
@@ -52,9 +52,13 @@ const Container = styled.div`
   overflow: hidden;
 `;
 
-const Background = ({children}) => (
-  <BackgroundColor>{children}</BackgroundColor>
-);
+const Background = ({children}) => {
+  // tried adding here but need to wait for loading state
+  // and css added not being picked up
+  return (
+    <BackgroundColor>{children}</BackgroundColor>
+  )
+};
 const LimitSizeDecorator = ({children}) => <Container>{children}</Container>;
 
 const NoDecorator = ({children}) => <>{children}</>;
@@ -142,7 +146,7 @@ export const decorators = [
   },
   (Story, context) => {
     const handlers = [instrumentationHandlers.createConsoleHandler()];
-
+    console.log(context);
     return (
       <NewsKitProvider
         theme={getThemeObject(context?.globals?.backgrounds?.value)}

--- a/site/templates/template-sections/interactive-demo-section.tsx
+++ b/site/templates/template-sections/interactive-demo-section.tsx
@@ -1,4 +1,4 @@
-import {Block} from 'newskit';
+import {Block, styled} from 'newskit';
 import React from 'react';
 import {PlaygroundProps} from '../../components/playground/types';
 import {ComponentPageCell} from '../../components/layout-cells';
@@ -8,6 +8,13 @@ export interface InteractiveDemoSectionProps {
   introduction: string | React.ReactElement;
   playground?: PlaygroundProps;
 }
+
+const StyledDiv = styled.div`
+  width: 100%;
+  height: 500px;
+  border-radius: 10px;
+  overflow: hidden;
+`;
 
 export const InteractiveDemoSection: React.FC<InteractiveDemoSectionProps> = ({
   introduction,
@@ -21,12 +28,15 @@ export const InteractiveDemoSection: React.FC<InteractiveDemoSectionProps> = ({
     {playground && (
       <ComponentPageCell>
         <Block spaceStack="space050">
-          <iframe
-            title="hello"
-            src="singleStory=true&embedded=true"
-            width="800"
-            height="200"
-          />
+          <StyledDiv>
+            <iframe
+              title="hello"
+              src="http://ncu-newskit-docs.s3-website-eu-west-1.amazonaws.com/ppdsc-2568-storybook/storybook/?path=/story/components-text-block--story-text-block-default&embedded=true&singleStory=true"
+              width="100%"
+              height="100%"
+              frameBorder="0"
+            />
+          </StyledDiv>
         </Block>
       </ComponentPageCell>
     )}

--- a/site/templates/template-sections/interactive-demo-section.tsx
+++ b/site/templates/template-sections/interactive-demo-section.tsx
@@ -1,6 +1,5 @@
 import {Block} from 'newskit';
 import React from 'react';
-import {Playground} from '../../components/playground';
 import {PlaygroundProps} from '../../components/playground/types';
 import {ComponentPageCell} from '../../components/layout-cells';
 import {CommonSection} from './common-section';
@@ -22,7 +21,12 @@ export const InteractiveDemoSection: React.FC<InteractiveDemoSectionProps> = ({
     {playground && (
       <ComponentPageCell>
         <Block spaceStack="space050">
-          <Playground {...playground} />
+          <iframe
+            title="hello"
+            src="singleStory=true&embedded=true"
+            width="800"
+            height="200"
+          />
         </Block>
       </ComponentPageCell>
     )}

--- a/src/text-block/__tests__/text-block.stories.tsx
+++ b/src/text-block/__tests__/text-block.stories.tsx
@@ -40,13 +40,20 @@ const StyledDiv = styled.div`
   border: 1px purple dotted;
 `;
 
-export const StoryTextBlockDefault = () => (
+export const StoryTextBlockDefault = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => (
   <>
     <StorybookHeading>TextBlock default</StorybookHeading>
-    <TextBlock stylePreset="inkContrast">{bodyString}</TextBlock>
+    <TextBlock stylePreset="inkContrast">{children}</TextBlock>
   </>
 );
 StoryTextBlockDefault.storyName = 'default';
+StoryTextBlockDefault.args = {
+  children: 'Telling the stories that matter',
+};
 
 export const StoryAsDifferentHtmlTag = () => (
   <>


### PR DESCRIPTION
PPDSC-XXXX

**What**

1. Background - why this is needed
2. What did you do
3. What does the reviewers should expect

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
