### PR TITLE
Feat/ppdsc 2726 change card default

### DIFF
--- a/site/components/media-list/__tests__/__snapshots__/media-list.test.tsx.snap
+++ b/site/components/media-list/__tests__/__snapshots__/media-list.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`Media List renders with custom layout 1`] = `
 }
 
 .emotion-11 .nk-headline-heading {
-  color: #2E3F54;
+  color: #09111C;
 }
 
 .emotion-11:hover:not(:disabled) .nk-headline-heading {
@@ -680,7 +680,7 @@ exports[`Media List renders with default layout 1`] = `
 }
 
 .emotion-11 .nk-headline-heading {
-  color: #2E3F54;
+  color: #09111C;
 }
 
 .emotion-11:hover:not(:disabled) .nk-headline-heading {

--- a/src/card/__tests__/__snapshots__/card.test.tsx.snap
+++ b/src/card/__tests__/__snapshots__/card.test.tsx.snap
@@ -4513,7 +4513,7 @@ exports[`Card with href renders correctly with actions 1`] = `
 }
 
 .emotion-3 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-3:hover:not(:disabled) .nk-headline-heading {
@@ -5025,7 +5025,7 @@ exports[`Card with href renders correctly with mediaInteractive set to true 1`] 
 }
 
 .emotion-7 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-7:hover:not(:disabled) .nk-headline-heading {
@@ -5412,7 +5412,7 @@ exports[`Card with href wraps the Headline component from cardBody with a link a
 }
 
 .emotion-4 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-4:hover:not(:disabled) .nk-headline-heading {
@@ -5538,7 +5538,7 @@ exports[`Card with href wraps the Headline component from cardBody with a link a
   display: inline;
   font: inherit;
   margin: 0;
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-6:hover:not(:disabled) {
@@ -5654,7 +5654,7 @@ exports[`Card with href wraps the Headline component from cardBody with a link a
 }
 
 .emotion-4 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-4:hover:not(:disabled) .nk-headline-heading {
@@ -5780,7 +5780,7 @@ exports[`Card with href wraps the Headline component from cardBody with a link a
   display: inline;
   font: inherit;
   margin: 0;
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-6:hover:not(:disabled) {
@@ -5890,7 +5890,7 @@ exports[`Card with href wraps the children of cardBody with a link provided as o
 }
 
 .emotion-3 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-3:hover:not(:disabled) .nk-headline-heading {
@@ -6035,7 +6035,7 @@ exports[`Card with href wraps the children of cardBody with a link provided as s
 }
 
 .emotion-3 .nk-headline-heading {
-  color: #3B3B3B;
+  color: #111111;
 }
 
 .emotion-3:hover:not(:disabled) .nk-headline-heading {

--- a/src/card/style-presets.ts
+++ b/src/card/style-presets.ts
@@ -9,7 +9,7 @@ export default {
   },
   headlineHeadingInteractive: {
     base: {
-      color: '{{colors.inkBase}}',
+      color: '{{colors.inkContrast}}',
     },
     hover: {
       color: '{{colors.interactivePrimary040}}',

--- a/src/theme/__tests__/__snapshots__/theme.test.ts.snap
+++ b/src/theme/__tests__/__snapshots__/theme.test.ts.snap
@@ -4249,7 +4249,7 @@ Object {
       "textDecoration": "underline",
     },
     "base": Object {
-      "color": "{{colors.inkBase}}",
+      "color": "{{colors.inkContrast}}",
     },
     "hover": Object {
       "color": "{{colors.interactivePrimary040}}",


### PR DESCRIPTION
PPDSC-2726

**What**

Changed Card default
Added notes in release confluence

<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->
