### PR TITLE
fix: AudioPlayerComposable - Prevent loop in firefox

### DIFF
--- a/src/audio-player-composable/audio-player-composable.tsx
+++ b/src/audio-player-composable/audio-player-composable.tsx
@@ -82,7 +82,7 @@ export const AudioPlayerComposable = ({
     }
     setCurrentTime(0);
     setDisplayDuration(0);
-  }, [src, initialTime, duration]);
+  }, []);
 
   const {
     audioEvents,

--- a/src/audio-player-composable/audio-player-composable.tsx
+++ b/src/audio-player-composable/audio-player-composable.tsx
@@ -74,15 +74,19 @@ export const AudioPlayerComposable = ({
   });
 
   useEffect(() => {
+    setCurrentTime(0);
+    setDisplayDuration(0);
+  }, [src]);
+
+  useEffect(() => {
     // On render onTimeUpdate will be fired and initialTime will be set as a value for currentTime state.
     // I can't set this one to the setCurrentTime state directly as the audioElement time
     // will still be 0, currentTime will be overridden to 0 and the audio will start from 0
+
     if (audioRef && audioRef.current && duration) {
       audioRef.current.currentTime = initialTime;
     }
-    setCurrentTime(0);
-    setDisplayDuration(0);
-  }, []);
+  }, [duration, initialTime]);
 
   const {
     audioEvents,

--- a/src/audio-player-composable/audio-player-composable.tsx
+++ b/src/audio-player-composable/audio-player-composable.tsx
@@ -74,19 +74,17 @@ export const AudioPlayerComposable = ({
   });
 
   useEffect(() => {
-    setCurrentTime(0);
-    setDisplayDuration(0);
-  }, [src]);
-
-  useEffect(() => {
     // On render onTimeUpdate will be fired and initialTime will be set as a value for currentTime state.
     // I can't set this one to the setCurrentTime state directly as the audioElement time
     // will still be 0, currentTime will be overridden to 0 and the audio will start from 0
 
-    if (audioRef && audioRef.current && duration) {
+    if (audioRef && audioRef.current) {
       audioRef.current.currentTime = initialTime;
     }
-  }, [duration, initialTime]);
+
+    setCurrentTime(0);
+    setDisplayDuration(0);
+  }, [src, initialTime]);
 
   const {
     audioEvents,


### PR DESCRIPTION
Renamed branch, original PR: #929

<!-- Replace #000 with github issue number e.g #1234 -->
closes #921

Currently the AudioPlayerComposable component has a problem with live streaming, where it infinitely loops the first second of audio if rendered in the Firefox browser. The component seems to work fine in Chrome. The reason it doesn't work in Firefox comes down to how the two browsers handle the onDurationChange event, or more specifically the value that is applied to `duration` for unbounded streams.

In Chrome the browser assigns `duration` the value of `Infinity`, which is in accordance with the [HTML spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-duration-dev) (see also [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/duration)), but in Firefox (for reasons I haven't been able to discover) the duration property is a continuously updated float.

Since we tie this continuous update to our component's `duration` state and we have that same `duration` listed as a dependency in a `useEffect`, this means that the callback for the `useEffect` is being continuously updated for unbounded streams in Firefox. That same callback is used to initialise the component by setting the current time to 0.

```
  useEffect(() => {
    if (audioRef && audioRef.current && duration) {
      audioRef.current.currentTime = initialTime;
    }
    setCurrentTime(0);
    setDisplayDuration(0);
  }, [src, initialTime, duration]);
```
This results in the infinite loop we are seeing where the audio's current time is constantly being reset as new audio data arrives and the value of `duration` changes.

Since we only really appear to want to call this function initially or when the src of the audio changes, I am proposing that we resolve the issue by removing `duration` as a factor of the component's initial setup entirely.


⚠️  There is an additional issue for Firefox that this does not solve, which is that autoplay still doesn't work.
<!---
This section will be used to indicate if we should move to a major version in the next release, remove if not revelant.
DO CONSIDER any of the following are breaking changes to a consumer, this is by no mean an exhaustive list.
-removing or renaming props
-removing or renaming tokens
-removing or renaming components
-removing or renaming exported functions
-in some cases, major bumps to peer dependencies
--->

<!---
Add any breaking change if present.
E.g:
BREAKING CHANGE: renames the foobar component's prop foo to bar
--->

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [x] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [x] The screen reader reads and flows through the elements as expected.
- [x] There are no new errors in the browser console coming from this PR.
- [x] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected
