### PR TITLE
fix(WWP-6619): update version tag regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ slack_notify: &slack_notify
   branch_pattern: 'main'
   # The following tag_pattern allows slack messages to be sent also when workflows are triggered by tags.
   # Such as in the release process. The tags MUST mirror the one used by release workflows filters.
-  tag_pattern: 'trigger-release@([0-9])(\.([0-9])){2}, v([0-9])(\.([0-9])){2}'
+  tag_pattern: 'trigger-release@([0-9]+)(\.([0-9]+)){2}, v([0-9]+)(\.([0-9]+)){2}'
   custom: |
     {
       "blocks": [
@@ -1088,7 +1088,7 @@ only_on_trigger_release_tag: &only_on_trigger_release_tag
   filters:
     tags:
       # The pattern must match the tag created in the github release interface. E.g: "trigger-release@5.0.1"
-      only: /^trigger-release@([0-9])(\.([0-9])){2}$/
+      only: /^trigger-release@([0-9]+)(\.([0-9]+)){2}$/
     branches:
       ignore: /.*/
 
@@ -1096,7 +1096,7 @@ only_on_version_tag: &only_on_version_tag
   filters:
     tags:
       # The pattern must match the tag created and pushed by bump_version make script. E.g: "v5.0.1"
-      only: /^v([0-9])(\.([0-9])){2}$/
+      only: /^v([0-9]+)(\.([0-9]+)){2}$/
     branches:
       ignore: /.*/
 
@@ -1104,7 +1104,7 @@ only_on_trigger_release_tag_codemod: &only_on_trigger_release_tag_codemod
   filters:
     tags:
       # The pattern must match the tag created in the github release interface. E.g: "trigger-release-codemod@5.0.1"
-      only: /^trigger-release-codemod@([0-9])(\.([0-9])){2}$/
+      only: /^trigger-release-codemod@([0-9]+)(\.([0-9]+)){2}$/
     branches:
       ignore: /.*/
 
@@ -1112,7 +1112,7 @@ only_on_version_tag_codemod: &only_on_version_tag_codemod
   filters:
     tags:
       # The pattern must match the tag created and pushed by bump_version_codemod make script. E.g: "codemod-v5.0.1"
-      only: /^codemod-v([0-9])(\.([0-9])){2}$/
+      only: /^codemod-v([0-9]+)(\.([0-9]+)){2}$/
     branches:
       ignore: /.*/
 


### PR DESCRIPTION
**- Ticket [WWP-6619](https://nidigitalsolutions.jira.com/browse/WWP-6619)**

This PR updates the version tag regex, which currently only supports single-digit numbers (0–9). As a result, the upcoming major release tag, `v10.0.0`, is not recognised, so the release workflow is not triggered.

**I have done:**
- [ ] Written unit tests against changes
- [ ] Written functional tests against the component and/or NewsKit site
- [ ] Updated relevant documentation

**I have tested manually:**
- [ ] The feature's functionality is working as expected on Chrome, Firefox, Safari and Edge
- [ ] The screen reader reads and flows through the elements as expected.
- [ ] There are no new errors in the browser console coming from this PR.
- [ ] When visual test is not added, it renders correctly on different browsers and mobile viewports (Safari, Firefox, small mobile viewport, tablet)
- [ ] The Playground feature is working as expected


<!---
Below sections are optional
--->

**Before:**
<!--- Drag and Drop your screenshot's here --->

**After:**
<!--- Drag and Drop your screenshot's here --->

**Who should review this PR:**
<!---
If you know someone is a domain expert for your PR,
someone who is deeply involved in the story,
ask them explicitly to review the PR.
--->

**How to test:**
<!--
If it's not immediately obvious how to test this PR, give instructions.
It's mandatory to update README.MD or development documentation if existing test strategy had changed.
-->

<!--
More info about raising an good PR: https://nidigitalsolutions.jira.com/wiki/spaces/NPP/pages/1319370846/Pull+Request
-->


[WWP-6619]: https://nidigitalsolutions.jira.com/browse/WWP-6619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ